### PR TITLE
Bug: Fix lock/unlock icon bug in wallet UI

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -418,6 +418,7 @@ bool WalletModel::setWalletLocked(bool locked, const SecureString& passPhrase, b
 {
     if (locked) {
         // Lock
+        wallet->fWalletUnlockAnonymizeOnly = false;
         return wallet->Lock();
     } else {
         // Unlock


### PR DESCRIPTION
**Bug in 3.6.983 QT Wallet**

**Steps to reproduce:**

1. Lock wallet
2. Unlock wallet for staking and anonymizing
3. Wait for icons to update to reflect state
4. Lock wallet
5. Notice that lock icon still reflects staking and anonymizing state

**Fixes**
The anonymizing state is properly being set to `false` in wallet model's `setWalletLocked()` method.