### PR TITLE
wallet relock fix

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -550,11 +550,9 @@ WalletModel::UnlockContext::UnlockContext(WalletModel* wallet, bool valid, bool 
 
 WalletModel::UnlockContext::~UnlockContext()
 {
-/*
     if (valid && relock) {
         wallet->setWalletLocked(true);
     }
-*/
 }
 
 void WalletModel::UnlockContext::CopyFrom(const UnlockContext& rhs)


### PR DESCRIPTION
See "Sending coins from locked wallet should return to locked state" bug in trello.
THe relock code was commented out in June by PIVX team member - probably she sis debugging and forgot  to uncomment it