### PR TITLE
Ability to lower the proposal fee

### DIFF
--- a/src/servicenode-budget.cpp
+++ b/src/servicenode-budget.cpp
@@ -160,7 +160,7 @@ void CBudgetManager::SubmitFinalBudget()
         return;
     
     std::vector<CBudgetProposal*> vBudgetProposals = budget.GetBudget();
-    std::string strBudgetName = "main";
+    std::string strBudgetName = "superblock-" + std::to_string(nBlockStart);
     std::vector<CTxBudgetPayment> vecTxBudgetPayments;
     
     for (auto vBudgetProposal : vBudgetProposals) {

--- a/src/servicenode-budget.h
+++ b/src/servicenode-budget.h
@@ -31,8 +31,6 @@ class CTxBudgetPayment;
 #define VOTE_YES 1
 #define VOTE_NO 2
 
-static const CAmount PROPOSAL_FEE_TX = (50 * COIN);
-static const CAmount BUDGET_FEE_TX = (50 * COIN);
 static const int64_t BUDGET_FEE_CONFIRMATIONS = 6;
 static const int64_t BUDGET_VOTE_UPDATE_MIN = 60 * 60;
 
@@ -47,6 +45,11 @@ int GetBudgetPaymentCycleBlocks();
 
 //Check the collateral transaction for the budget proposal/finalized budget
 bool IsBudgetCollateralValid(uint256 nTxCollateralHash, uint256 nExpectedHash, std::string& strError, int64_t& nTime, int& nConf);
+
+// Proposal submission collateral amount
+CAmount GetProposalFee();
+// Final budget submission collateral amount
+CAmount GetBudgetFee();
 
 //
 // CBudgetVote - Allow a servicenode node to vote and broadcast throughout the network

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -91,6 +91,8 @@ bool IsSporkActive(int nSporkID)
         if (nSporkID == SPORK_13_ENABLE_SUPERBLOCKS) r = SPORK_13_ENABLE_SUPERBLOCKS_DEFAULT;
         if (nSporkID == SPORK_14_NEW_PROTOCOL_ENFORCEMENT) r = SPORK_14_NEW_PROTOCOL_ENFORCEMENT_DEFAULT;
         if (nSporkID == SPORK_17_EXPL_FIX) r = SPORK_17_EXPL_FIX_DEFAULT;
+        if (nSporkID == SPORK_18_PROPOSAL_FEE) r = SPORK_18_PROPOSAL_FEE_DEFAULT;
+        if (nSporkID == SPORK_18_PROPOSAL_FEE_AMOUNT) r = SPORK_18_PROPOSAL_FEE_AMOUNT_DEFAULT;
 
         if (r == -1) LogPrintf("GetSpork::Unknown Spork %d\n", nSporkID);
     }
@@ -119,6 +121,8 @@ int64_t GetSporkValue(int nSporkID)
         if (nSporkID == SPORK_13_ENABLE_SUPERBLOCKS) r = SPORK_13_ENABLE_SUPERBLOCKS_DEFAULT;
         if (nSporkID == SPORK_14_NEW_PROTOCOL_ENFORCEMENT) r = SPORK_14_NEW_PROTOCOL_ENFORCEMENT_DEFAULT;
         if (nSporkID == SPORK_17_EXPL_FIX) r = SPORK_17_EXPL_FIX_DEFAULT;
+        if (nSporkID == SPORK_18_PROPOSAL_FEE) r = SPORK_18_PROPOSAL_FEE_DEFAULT;
+        if (nSporkID == SPORK_18_PROPOSAL_FEE_AMOUNT) r = SPORK_18_PROPOSAL_FEE_AMOUNT_DEFAULT;
 
         if (r == -1) LogPrintf("GetSpork::Unknown Spork %d\n", nSporkID);
     }
@@ -266,6 +270,8 @@ int CSporkManager::GetSporkIDByName(std::string strName)
     if (strName == "SPORK_13_ENABLE_SUPERBLOCKS") return SPORK_13_ENABLE_SUPERBLOCKS;
     if (strName == "SPORK_14_NEW_PROTOCOL_ENFORCEMENT") return SPORK_14_NEW_PROTOCOL_ENFORCEMENT;
     if (strName == "SPORK_17_EXPL_FIX") return SPORK_17_EXPL_FIX;
+    if (strName == "SPORK_18_PROPOSAL_FEE") return SPORK_18_PROPOSAL_FEE;
+    if (strName == "SPORK_18_PROPOSAL_FEE_AMOUNT") return SPORK_18_PROPOSAL_FEE_AMOUNT;
 
     return -1;
 }
@@ -284,6 +290,8 @@ std::string CSporkManager::GetSporkNameByID(int id)
     if (id == SPORK_13_ENABLE_SUPERBLOCKS) return "SPORK_13_ENABLE_SUPERBLOCKS";
     if (id == SPORK_14_NEW_PROTOCOL_ENFORCEMENT) return "SPORK_14_NEW_PROTOCOL_ENFORCEMENT";
     if (id == SPORK_17_EXPL_FIX) return "SPORK_17_EXPL_FIX";
+    if (id == SPORK_18_PROPOSAL_FEE) return "SPORK_18_PROPOSAL_FEE";
+    if (id == SPORK_18_PROPOSAL_FEE_AMOUNT) return "SPORK_18_PROPOSAL_FEE_AMOUNT";
 
     return "Unknown";
 }

--- a/src/spork.h
+++ b/src/spork.h
@@ -25,7 +25,7 @@ using namespace boost;
     - This would result in old clients getting confused about which spork is for what
 */
 #define SPORK_START 10001
-#define SPORK_END 10016
+#define SPORK_END 10018
 
 #define SPORK_2_SWIFTTX 10001
 #define SPORK_3_SWIFTTX_BLOCK_FILTERING 10002
@@ -39,6 +39,8 @@ using namespace boost;
 #define SPORK_13_ENABLE_SUPERBLOCKS 10012
 #define SPORK_14_NEW_PROTOCOL_ENFORCEMENT 10013
 #define SPORK_17_EXPL_FIX 10016
+#define SPORK_18_PROPOSAL_FEE 10017
+#define SPORK_18_PROPOSAL_FEE_AMOUNT 10018
 
 #define SPORK_2_SWIFTTX_DEFAULT 978307200                         //2001-1-1
 #define SPORK_3_SWIFTTX_BLOCK_FILTERING_DEFAULT 1424217600        //2015-2-18
@@ -52,6 +54,8 @@ using namespace boost;
 #define SPORK_13_ENABLE_SUPERBLOCKS_DEFAULT 4070908800            //OFF
 #define SPORK_14_NEW_PROTOCOL_ENFORCEMENT_DEFAULT 4070908800      //OFF
 #define SPORK_17_EXPL_FIX_DEFAULT 4070908800                      //OFF
+#define SPORK_18_PROPOSAL_FEE_DEFAULT 4070908800                  //OFF
+#define SPORK_18_PROPOSAL_FEE_AMOUNT_DEFAULT 50                   //50 BLOCK
 
 class CSporkMessage;
 class CSporkManager;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2060,7 +2060,7 @@ bool CWallet::GetBudgetSystemCollateralTX(CWalletTx& tx, uint256 hash, bool useI
     int64_t nFeeRet = 0;
     std::string strFail = "";
     vector<pair<CScript, int64_t> > vecSend;
-    vecSend.push_back(make_pair(scriptChange, BUDGET_FEE_TX));
+    vecSend.push_back(make_pair(scriptChange, GetBudgetFee()));
 
     CCoinControl* coinControl = NULL;
     bool success = CreateTransaction(vecSend, tx, reservekey, nFeeRet, strFail, coinControl, ALL_COINS, useIX, (CAmount)0);


### PR DESCRIPTION
Added the ability to adjust the proposal fee via spork.

**Notes:**
- Default fee remains at `50 BLOCK` (backwards compatible)
- This will cause older clients to fork if value is changed to **anything less than 50**
- `SPORK_18_PROPOSAL_FEE` enables the feature
- `SPORK_18_PROPOSAL_FEE_AMOUNT` sets a specific proposal fee amount (this value is also used for the final budget submission fee)
- If the new fee is less than the previous fee all outstanding budgets will be invalidated (requires clearing old budgets with `SPORK_11_RESET_BUDGET 1`)