### PR TITLE
A form is now displayed upon program start if the user's wallet is cu…

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -97,8 +97,8 @@ QT_MOC_CPP = \
   qt/xbridgeui/moc_xbridgeaddressbookview.cpp \
   qt/xbridgeui/moc_xbridgetransactiondialog.cpp \
   qt/xbridgeui/moc_xbridgetransactionsmodel.cpp \
-  qt/xbridgeui/moc_xbridgetransactionsview.cpp \
-  qt/moc_walletnonencryptwarningdialog.cpp 
+  qt/xbridgeui/moc_xbridgetransactionsview.cpp
+   
 
 BITCOIN_MM = \
   qt/macdockiconhandler.mm \
@@ -180,7 +180,8 @@ BITCOIN_QT_H = \
   qt/xbridgeui/xbridgeaddressbookview.h \
   qt/xbridgeui/xbridgetransactiondialog.h \
   qt/xbridgeui/xbridgetransactionsmodel.h \
-  qt/xbridgeui/xbridgetransactionsview.h
+  qt/xbridgeui/xbridgetransactionsview.h \
+  qt/walletnonencryptwarningdialog.h
 
 
 RES_ICONS = \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -98,9 +98,7 @@ QT_MOC_CPP = \
   qt/xbridgeui/moc_xbridgetransactiondialog.cpp \
   qt/xbridgeui/moc_xbridgetransactionsmodel.cpp \
   qt/xbridgeui/moc_xbridgetransactionsview.cpp \
-  qt/moc_walletnonencryptwarningdialog.cpp \
-  qt/moc_walletnonencryptwarningdialog.cpp
-
+  qt/moc_walletnonencryptwarningdialog.cpp 
 
 BITCOIN_MM = \
   qt/macdockiconhandler.mm \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -41,7 +41,8 @@ QT_FORMS_UI = \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/sendcoinsentry.ui \
   qt/forms/signverifymessagedialog.ui \
-  qt/forms/transactiondescdialog.ui
+  qt/forms/transactiondescdialog.ui \
+  qt/forms/walletnonencryptwarningdialog.ui
 
 QT_MOC_CPP = \
   qt/moc_addressbookpage.cpp \
@@ -96,7 +97,9 @@ QT_MOC_CPP = \
   qt/xbridgeui/moc_xbridgeaddressbookview.cpp \
   qt/xbridgeui/moc_xbridgetransactiondialog.cpp \
   qt/xbridgeui/moc_xbridgetransactionsmodel.cpp \
-  qt/xbridgeui/moc_xbridgetransactionsview.cpp
+  qt/xbridgeui/moc_xbridgetransactionsview.cpp \
+  qt/moc_walletnonencryptwarningdialog.cpp \
+  qt/moc_walletnonencryptwarningdialog.cpp
 
 
 BITCOIN_MM = \
@@ -304,8 +307,8 @@ BITCOIN_QT_CPP += \
   qt/walletframe.cpp \
   qt/walletmodel.cpp \
   qt/walletmodeltransaction.cpp \
-  qt/walletview.cpp
-
+  qt/walletview.cpp \
+  qt/walletnonencryptwarningdialog.cpp
 endif
 
 RES_IMAGES = \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -93,6 +93,7 @@ QT_MOC_CPP = \
   qt/moc_walletframe.cpp \
   qt/moc_walletmodel.cpp \
   qt/moc_walletview.cpp \
+  qt/moc_walletnonencryptwarningdialog.cpp \
   qt/xbridgeui/moc_xbridgeaddressbookmodel.cpp \
   qt/xbridgeui/moc_xbridgeaddressbookview.cpp \
   qt/xbridgeui/moc_xbridgetransactiondialog.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -370,6 +370,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #ifdef ENABLE_WALLET
     strUsage += HelpMessageGroup(_("Wallet options:"));
     strUsage += HelpMessageOpt("-createwalletbackups=<n>", _("Number of automatic wallet backups (default: 10)"));
+    strUsage += HelpMessageOpt("-shownoencryptwarning=<n>", _("Enable or disable wallet non-encrypt notice dialog upon startup (default: 1)"));
     strUsage += HelpMessageOpt("-disablewallet", _("Do not load the wallet and disable wallet RPC calls"));
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), 100));
     if (GetBoolArg("-help-debug", false))

--- a/src/qt/blocknetdx.cpp
+++ b/src/qt/blocknetdx.cpp
@@ -36,8 +36,8 @@
 
 #ifdef ENABLE_WALLET
 #include "wallet.h"
-#include "qt/walletnonencryptwarningdialog.h"
-#include "qt/askpassphrasedialog.h"
+#include "walletnonencryptwarningdialog.h"
+#include "askpassphrasedialog.h"
 #endif
 
 #include <stdint.h>

--- a/src/qt/blocknetdx.cpp
+++ b/src/qt/blocknetdx.cpp
@@ -36,6 +36,8 @@
 
 #ifdef ENABLE_WALLET
 #include "wallet.h"
+#include "walletnonencryptwarningdialog.h"
+#include "askpassphrasedialog.h"
 #endif
 
 #include <stdint.h>
@@ -465,7 +467,28 @@ void BitcoinApplication::initializeResult(int retval)
 #ifdef ENABLE_WALLET
         if (pwalletMain) {
             walletModel = new WalletModel(pwalletMain, optionsModel);
+            
+            /// Warn user that the wallet is not encrypted and auto-backups are enabled
+            if (walletModel)
+            {
+                int nWalletBackups = GetArg("-createwalletbackups", 10);
+                bool enableWarning = GetBoolArg("-shownoencryptwarning", true);
+                if (nWalletBackups>0 && enableWarning)
+                {
+                    WalletModel::EncryptionStatus status = walletModel->getEncryptionStatus();
+                    if (status == WalletModel::EncryptionStatus::Unencrypted)
+                    {
+                        WalletNonEncryptWarningDialog dlg;
+                        if (dlg.exec())
+                        {
+                            AskPassphraseDialog dlg(AskPassphraseDialog::Encrypt, window, walletModel);
+                            dlg.exec();
 
+                            //emit encryptionStatusChanged(walletModel->getEncryptionStatus());
+                        }
+                    }
+                }
+            }
             window->addWallet(BitcoinGUI::DEFAULT_WALLET, walletModel);
             window->setCurrentWallet(BitcoinGUI::DEFAULT_WALLET);
 

--- a/src/qt/blocknetdx.cpp
+++ b/src/qt/blocknetdx.cpp
@@ -36,8 +36,8 @@
 
 #ifdef ENABLE_WALLET
 #include "wallet.h"
-#include "walletnonencryptwarningdialog.h"
-#include "askpassphrasedialog.h"
+#include "qt/walletnonencryptwarningdialog.h"
+#include "qt/askpassphrasedialog.h"
 #endif
 
 #include <stdint.h>

--- a/src/qt/forms/walletnonencryptwarningdialog.ui
+++ b/src/qt/forms/walletnonencryptwarningdialog.ui
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>WalletNonEncryptWarningDialog</class>
+ <widget class="QDialog" name="WalletNonEncryptWarningDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>390</width>
+    <height>222</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Wallet Auto-Backup Notification</string>
+  </property>
+  <widget class="QGroupBox" name="groupBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>0</y>
+     <width>371</width>
+     <height>211</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string/>
+   </property>
+   <widget class="QPushButton" name="ignorePushButton">
+    <property name="geometry">
+     <rect>
+      <x>40</x>
+      <y>160</y>
+      <width>89</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Ignore</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="encryptPushButton">
+    <property name="geometry">
+     <rect>
+      <x>240</x>
+      <y>160</y>
+      <width>89</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Encrypt</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label">
+    <property name="geometry">
+     <rect>
+      <x>30</x>
+      <y>20</y>
+      <width>311</width>
+      <height>61</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>NOTICE: Auto Wallet Backups are currently enabled and the wallet is NOT encrypted.</string>
+    </property>
+    <property name="wordWrap">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_2">
+    <property name="geometry">
+     <rect>
+      <x>30</x>
+      <y>100</y>
+      <width>271</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Select one of the following choices:</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="doNotShowAgainCheckBox">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>300</y>
+      <width>241</width>
+      <height>23</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Do not show this warning again</string>
+    </property>
+   </widget>
+   <zorder>doNotShowAgainCheckBox</zorder>
+   <zorder>ignorePushButton</zorder>
+   <zorder>encryptPushButton</zorder>
+   <zorder>label</zorder>
+   <zorder>label_2</zorder>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/walletnonencryptwarningdialog.cpp
+++ b/src/qt/walletnonencryptwarningdialog.cpp
@@ -1,0 +1,49 @@
+/// Copyright (c) 2011-2014 The Bitcoin developers
+/// Copyright (c) 2014-2015 The Dash developers
+/// Copyright (c) 2015-2017 The BlocknetDX developers
+/// Distributed under the MIT/X11 software license, see the accompanying
+/// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/// This module handles the events and callbacks from the WalletNonEncryptWarningDialog
+/// form that is displayed upon program start if the user's wallet is currently un-encrypted.
+/// This notice dialog may be disabled with a setting in the blocknextdx.conf file.
+/// The flag is called -shownoencryptwarning and if set to 0 the notice dialog is disabled.
+/// Default is 1 or true.
+
+
+#include "qt/walletnonencryptwarningdialog.h"
+#include "ui_walletnonencryptwarningdialog.h"
+
+#include "guiutil.h"
+
+
+WalletNonEncryptWarningDialog::WalletNonEncryptWarningDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::WalletNonEncryptWarningDialog)
+{
+    ui->setupUi(this);
+    encryptWallet = false;
+}
+
+WalletNonEncryptWarningDialog::~WalletNonEncryptWarningDialog()
+{
+    delete ui;
+}
+
+void WalletNonEncryptWarningDialog::on_ignorePushButton_clicked()
+{
+    //encryptWallet = false;
+    QDialog::done(false);
+    //QDialog::close();
+}
+
+void WalletNonEncryptWarningDialog::on_encryptPushButton_clicked()
+{
+    //encryptWallet = true;
+    QDialog::done(true);
+}
+
+void WalletNonEncryptWarningDialog::on_doNotShowAgainCheckBox_toggled(bool checked)
+{
+
+}

--- a/src/qt/walletnonencryptwarningdialog.h
+++ b/src/qt/walletnonencryptwarningdialog.h
@@ -1,0 +1,44 @@
+/// Copyright (c) 2011-2014 The Bitcoin developers
+/// Copyright (c) 2014-2015 The Dash developers
+/// Copyright (c) 2015-2017 The BlocknetDX developers
+/// Distributed under the MIT/X11 software license, see the accompanying
+/// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/// This module handles the events and callbacks from the WalletNonEncryptWarningDialog
+/// form that is displayed upon program start if the user's wallet is currently un-encrypted.
+/// This notice dialog may be disabled with a setting in the blocknextdx.conf file.
+/// The flag is called -shownoencryptwarning and if set to 0 the notice dialog is disabled.
+/// Default is 1 or true.
+
+
+#ifndef WALLETNONENCRYPTWARNINGDIALOG_H
+#define WALLETNONENCRYPTWARNINGDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class WalletNonEncryptWarningDialog;
+}
+
+class WalletNonEncryptWarningDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit WalletNonEncryptWarningDialog(QWidget *parent = 0);
+    ~WalletNonEncryptWarningDialog();
+
+private slots:
+    void on_ignorePushButton_clicked();
+
+    void on_encryptPushButton_clicked();
+
+    void on_doNotShowAgainCheckBox_toggled(bool checked);
+
+private:
+    Ui::WalletNonEncryptWarningDialog *ui;
+public:
+    bool encryptWallet;
+};
+
+#endif // WALLETNONENCRYPTWARNINGDIALOG_H


### PR DESCRIPTION
…rrently un-encrypted. And

autobackup number is greater then 0. This notice dialog may be disabled with a setting in the blocknextdx.conf file. The flag is called -shownoencryptwarning and if set to 0 the notice dialog is disabled. Default is 1 or true.