### PR TITLE
Fixes loading progress for wallet

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2869,7 +2869,7 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
                 throw runtime_error("TopUpKeyPool() : writing generated key failed");
             setKeyPool.insert(nEnd);
             LogPrintf("keypool added key %d, size=%u\n", nEnd, setKeyPool.size());
-            double dProgress = 100.f * nEnd / (nTargetSize + 1);
+            double dProgress = 100.f * setKeyPool.size() / (nTargetSize + 1);
             std::string strMsg = strprintf(_("Loading wallet... (%3.2f %%)"), dProgress);
             uiInterface.InitMessage(strMsg);
         }


### PR DESCRIPTION
XBridgeSession::init() requests new key on every init (eventually calls TopUpKeys) after the normal app init was done.
So the key number in this specific case is greater than size of keypool (increases by 1 everytime app is started).

Bug was noticed only when new wallet is loaded because then message stays longer. However, message is always visible (although for a short time), and it will be going to higher and higher percent everytime. So I updated it to calculate real percentage with actual keypool size, instead of key number.

This calculation is more precise anyway, even if Xbridge::init() behaviour changes.