### PR TITLE
Add optional validate parameter to dxCreate and dxAccept.

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -372,6 +372,7 @@ static const CRPCCommand vRPCCommands[] =
         {"xbridge", "dxCancelTransaction",                  &dxCancelTransaction,        true, true, true},
         {"xbridge", "dxGetTradeHistory",                    &dxGetTradeHistory,          true, true, true},
         {"xbridge", "dxGetOrderBook",                       &dxGetOrderBook,             true, true, true},
+        {"xbridge", "dxrollbackTransaction",                &dxrollbackTransaction,      true, true, true}
     #endif // ENABLE_WALLET
 };
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -259,7 +259,35 @@ extern json_spirit::Value mnsync(const json_spirit::Array& params, bool fHelp);
   * @param params The list of input params - should be empty
   * @param fHelp If is true then an exception with parameter description message will be thrown
   * @return The list of open and pending transactions as JSON value. Open transactions go first.
+  * * Example:<br>
+  * \verbatim
+    dxGetTransactions
+￼
+    [
+        {
+            "id" : "1632417312d5ea676abb88b8fb48ace1a11e9b1a937fc24ff79296d9d2963b32",
+            "from" : "BLOCK",
+            "fromAddress" : "",
+            "fromAmount" : 0.01000000000000000,
+            "to" : "SYS",
+            "toAddress" : "",
+            "toAmount" : 0.50000000000000000,
+            "state" : "Open"
+        },
+        {
+            "id" : "6be548bc46a3dcc69b6d56529948f7e679dd96657f85f5870a017e005caa050a",
+            "from" : "LTC",
+            "fromAddress" : "",
+            "fromAmount" : 0.00010000000000000,
+            "to" : "SYS",
+            "toAddress" : "",
+            "toAmount" : 0.00010000000000000,
+            "state" : "Open"
+        }
+    ]
+  * \endverbatim
   */
+
 extern json_spirit::Value dxGetTransactions(const json_spirit::Array& params, bool fHelp);
 
 /**
@@ -269,6 +297,33 @@ extern json_spirit::Value dxGetTransactions(const json_spirit::Array& params, bo
  * returned, not only successfully completed ones
  * @param fHelp If is true then an exception with parameter description message will be thrown
  * @return The list of historical transaction  as a JSON value
+ * * Example:<br>
+ * \verbatim
+    dxGetTransactionsHistory ALL
+￼
+    [
+        {
+            "id" : "1632417312d5ea676abb88b8fb48ace1a11e9b1a937fc24ff79296d9d2963b32",
+            "from" : "BLOCK",
+            "fromAddress" : "",
+            "fromAmount" : 0.01000000000000000,
+            "to" : "SYS",
+            "toAddress" : "",
+            "toAmount" : 0.50000000000000000,
+            "state" : "Finished"
+        },
+        {
+            "id" : "6be548bc46a3dcc69b6d56529948f7e679dd96657f85f5870a017e005caa050a",
+            "from" : "LTC",
+            "fromAddress" : "",
+            "fromAmount" : 0.00010000000000000,
+            "to" : "SYS",
+            "toAddress" : "",
+            "toAmount" : 0.00010000000000000,
+            "state" : "Finished"
+        }
+    ]
+ * \endverbatim
  */
 extern json_spirit::Value dxGetTransactionsHistory(const json_spirit::Array& params, bool fHelp);
 
@@ -278,6 +333,23 @@ extern json_spirit::Value dxGetTransactionsHistory(const json_spirit::Array& par
  * params[0] : transaction id
  * @param fHelp If is true then an exception with parameter description message will be thrown
  * @return The detailed description of given transaction as a JSON value
+ * * Example:<br>
+ * \verbatim
+    dxGetTransactionInfo 91d0ea83edc79b9a2041c51d08037cff87c181efb311a095dfdd4edbcc7993a9
+￼
+    [
+        {
+            "id" : "91d0ea83edc79b9a2041c51d08037cff87c181efb311a095dfdd4edbcc7993a9",
+            "from" : "LTC",
+            "fromAddress" : "",
+            "fromAmount" : 0.01000000000000000,
+            "to" : "BLOCK",
+            "toAddress" : "",
+            "toAmount" : 0.05500000000000000,
+            "state" : "Open"
+        }
+    ]
+ * \endverbatim
  */
 extern json_spirit::Value dxGetTransactionInfo(const json_spirit::Array& params, bool fHelp);
 
@@ -286,6 +358,16 @@ extern json_spirit::Value dxGetTransactionInfo(const json_spirit::Array& params,
  * @param params The list of input params, should be empty
  * @param fHelp If is true then an exception with parameter description message will be thrown
  * @return The list of available currencies as a JSON value
+ * * Example:<br>
+ * \verbatim
+    {
+        "DCR" : "",
+        "DEC" : "",
+        "DOGE" : "",
+        "LTC" : "",
+        "SYS" : ""
+    }
+ * \endverbatim
  */
 extern json_spirit::Value dxGetCurrencies(const json_spirit::Array& params, bool fHelp);
 
@@ -300,6 +382,19 @@ extern json_spirit::Value dxGetCurrencies(const json_spirit::Array& params, bool
  * params[5] : amount being received<br>
  * @param fHelp If is true then an exception with parameter description message will be thrown
  * @return The transaction created, as a JSON value
+ * * Example:<br>
+ * \verbatim
+ *
+    dxCreateTransaction  1NDqZ7piDqyDhNveWS48kDSwPdyJLEEcCp SYS 1.3 LRuXAU2fdSU7imXzk8cTy2k3heMK5vTuQ4 LTC 0.13
+    {
+        "from" : "1NDqZ7piDqyDhNveWS48kDSwPdyJLEEcCp",
+        "fromCurrency" : "SYS",
+        "fromAmount" : 1.30000000000000004,
+        "to" : "LRuXAU2fdSU7imXzk8cTy2k3heMK5vTuQ4",
+        "toCurrency" : "LTC",
+        "toAmount" : 0.13000000000000000
+    }
+ * \endverbatim
  */
 extern json_spirit::Value dxCreateTransaction(const json_spirit::Array& params, bool fHelp);
 
@@ -311,6 +406,15 @@ extern json_spirit::Value dxCreateTransaction(const json_spirit::Array& params, 
  * params[2] : receiving address<br>
  * @param fHelp If is true then an exception with parameter description message will be thrown
  * @return The status of the operation
+ * * Example:<br>
+ * \verbatim￼
+    dxAcceptTransaction 6be548bc46a3dcc69b6d56529948f7e679dd96657f85f5870a017e005caa050a 1NDqZ7piDqyDhNveWS48kDSwPdyJLEEcCp LRuXAU2fdSU7imXzk8cTy2k3heMK5vTuQ4
+    {
+        "id" : "6be548bc46a3dcc69b6d56529948f7e679dd96657f85f5870a017e005caa050a",
+        "from" : "1NDqZ7piDqyDhNveWS48kDSwPdyJLEEcCp",
+        "to" : "LRuXAU2fdSU7imXzk8cTy2k3heMK5vTuQ4"
+    }
+ * \endverbatim
  */
 extern json_spirit::Value dxAcceptTransaction(const json_spirit::Array& params, bool fHelp);
 
@@ -320,8 +424,32 @@ extern json_spirit::Value dxAcceptTransaction(const json_spirit::Array& params, 
  * params[0] : transaction id<br>
  * @param fHelp If is true then an exception with parameter description message will be thrown
  * @return The status of the operation
+ * * Example:<br>
+ * \verbatim ￼
+    dxCancelTransaction 6be548bc46a3dcc69b6d56529948f7e679dd96657f85f5870a017e005caa050a
+    {
+        "id" : "6be548bc46a3dcc69b6d56529948f7e679dd96657f85f5870a017e005caa050a"
+    }
+ * \endverbatim
+
  */
 extern json_spirit::Value dxCancelTransaction(const json_spirit::Array& params, bool fHelp);
+
+/**
+ * @brief Rollback given transaction
+ * @param params The list of input params:<br>
+ * params[0] : transaction id<br>
+ * @param fHelp If is true then an exception with parameter description message will be thrown
+ * @return The status of the operation
+ * * Example:<br>
+ * \verbatim
+    dxrollbackTransaction 6be548bc46a3dcc69b6d56529948f7e679dd96657f85f5870a017e005caa050a
+    {
+        "id" : "6be548bc46a3dcc69b6d56529948f7e679dd96657f85f5870a017e005caa050a"
+    }
+ * \endverbatim
+ */
+extern json_spirit::Value dxrollbackTransaction(const json_spirit::Array& params, bool fHelp);
 
 /**
  * @brief Returns trading history as a 'price chart'
@@ -332,6 +460,25 @@ extern json_spirit::Value dxCancelTransaction(const json_spirit::Array& params, 
  * params[3] : end time, Unix time<br>
  * @param fHelp If is true then an exception with parameter description message will be thrown
  * @return The list of completed transactions as 'price chart' points
+ * * Example:<br>
+ * \verbatim
+  [
+   {
+        "bids" : [
+            [
+                1.00000000000000000,
+                0.00200000000000000
+            ],
+            [
+                1.00000000000000000,
+                0.00100000000000000
+            ]
+         ],
+        "asks" : [
+        ]
+    }
+  ]
+ * \endverbatim
  */
 extern json_spirit::Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp);
 

--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -600,6 +600,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
             {
                 const auto &tr = bidsItem->second;
                 const auto bidPrice = xBridgeValueFromAmount(tr->fromAmount) / xBridgeValueFromAmount(tr->toAmount);
+                bids.emplace_back(tr->id.GetHex());
                 bids.emplace_back(bidPrice);
                 bids.emplace_back(xBridgeValueFromAmount(tr->fromAmount));
             }
@@ -619,6 +620,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
             {
                 const auto &tr = asksItem->second;
                 const auto askPrice = xBridgeValueFromAmount(tr->fromAmount) / xBridgeValueFromAmount(tr->toAmount);
+                asks.emplace_back(tr->id.GetHex());
                 asks.emplace_back(askPrice);
                 asks.emplace_back(xBridgeValueFromAmount(tr->fromAmount));
             }
@@ -666,6 +668,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
                 Array tmp;
                 //calculate bids and push to array
                 const auto bidPrice = xBridgeValueFromAmount(bidsVector[i]->fromAmount) / xBridgeValueFromAmount(bidsVector[i]->toAmount);
+                tmp.emplace_back(bidsVector[i]->id.GetHex());
                 tmp.emplace_back(bidPrice);
                 tmp.emplace_back(xBridgeValueFromAmount(bidsVector[i]->fromAmount));
                 bids.emplace_back(tmp);
@@ -676,6 +679,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
                 Array tmp;
                 //calculate asks and push to array
                 const auto askPrice = xBridgeValueFromAmount(asksVector[i]->fromAmount) / xBridgeValueFromAmount(asksVector[i]->toAmount);
+                tmp.emplace_back(asksVector[i]->id.GetHex());
                 tmp.emplace_back(askPrice);
                 tmp.emplace_back(xBridgeValueFromAmount(asksVector[i]->fromAmount));
                 asks.emplace_back(tmp);
@@ -691,6 +695,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
                 const auto &tr = trEntry.second;
                 Array tmp;
                 const auto bidPrice = xBridgeValueFromAmount(tr->fromAmount) / xBridgeValueFromAmount(tr->toAmount);
+                tmp.emplace_back(tr->id.GetHex());
                 tmp.emplace_back(bidPrice);
                 tmp.emplace_back(xBridgeValueFromAmount(tr->fromAmount));
                 bids.emplace_back(tmp);
@@ -700,6 +705,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
                 const auto &tr = trEntry.second;
                 Array tmp;
                 const auto askPrice = xBridgeValueFromAmount(tr->fromAmount) / xBridgeValueFromAmount(tr->toAmount);
+                tmp.emplace_back(tr->id.GetHex());
                 tmp.emplace_back(askPrice);
                 tmp.emplace_back(xBridgeValueFromAmount(tr->fromAmount));
                 asks.emplace_back(tmp);

--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -391,7 +391,7 @@ Value dxGetCurrencies(const Array & params, bool fHelp)
 
 //******************************************************************************
 //******************************************************************************
-Value dxCreateTransaction(const Array & params, bool fHelp)
+Value dxCreateTransaction(const Array &params, bool fHelp)
 {
     if (fHelp) {
         throw runtime_error("dxCreateTransaction "

--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -489,6 +489,29 @@ Value dxCancelTransaction(const Array & params, bool fHelp)
     return obj;
 }
 
+//******************************************************************************
+//******************************************************************************
+json_spirit::Value dxrollbackTransaction(const json_spirit::Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+    {
+        throw runtime_error("dxrollbackTransaction (id)\n"
+                            "Rollback xbridge transaction.");
+    }
+    LOG() << "rpc rollback transaction " << __FUNCTION__;
+    uint256 id(params[0].get_str());
+    Object obj;
+    if(XBridgeApp::instance().rollbackXBridgeTransaction(id) == xbridge::SUCCESS)
+    {
+        obj.push_back(Pair("id",id.GetHex()));
+        return  obj;
+    }
+    obj.push_back(Pair("id", id.GetHex()));
+    return obj;
+}
+
+//******************************************************************************
+//******************************************************************************
 json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
 {
     if (fHelp || (params.size() != 3 && params.size() != 4))

--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -61,12 +61,13 @@ Value dxGetTransactions(const Array & params, bool fHelp)
     if (fHelp || params.size() > 0)
     {
         Object error;
-        error.push_back(Pair("error",
-                             "invalid parameters: dxGetTransactions\nList transactions."));
+        error.emplace_back(Pair("error",
+                                "This function does not accept any parameter"));
+        error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
         return  error;
     }
 
-    Array arr;    
+    Array arr;
 
     // pending tx
     {
@@ -79,15 +80,15 @@ Value dxGetTransactions(const Array & params, bool fHelp)
         {
             Object jtr;
             const auto tr = trEntry.second;
-            jtr.push_back(Pair("id",            tr->id.GetHex()));
-            jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",   tr->from));
-            jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
-            jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",     tr->to));
-            jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
-            jtr.push_back(Pair("state",         tr->strState()));
-            arr.push_back(jtr);
+            jtr.emplace_back(Pair("id",            tr->id.GetHex()));
+            jtr.emplace_back(Pair("from",          tr->fromCurrency));
+            jtr.emplace_back(Pair("fromAddress",   tr->from));
+            jtr.emplace_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
+            jtr.emplace_back(Pair("to",            tr->toCurrency));
+            jtr.emplace_back(Pair("toAddress",     tr->to));
+            jtr.emplace_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
+            jtr.emplace_back(Pair("state",         tr->strState()));
+            arr.emplace_back(jtr);
         }
     }
 
@@ -102,15 +103,15 @@ Value dxGetTransactions(const Array & params, bool fHelp)
         {
             Object jtr;
             const auto &tr = trEntry.second;
-            jtr.push_back(Pair("id",            tr->id.GetHex()));
-            jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",   tr->from));
-            jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
-            jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",     tr->to));
-            jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
-            jtr.push_back(Pair("state",         tr->strState()));
-            arr.push_back(jtr);
+            jtr.emplace_back(Pair("id",            tr->id.GetHex()));
+            jtr.emplace_back(Pair("from",          tr->fromCurrency));
+            jtr.emplace_back(Pair("fromAddress",   tr->from));
+            jtr.emplace_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
+            jtr.emplace_back(Pair("to",            tr->toCurrency));
+            jtr.emplace_back(Pair("toAddress",     tr->to));
+            jtr.emplace_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
+            jtr.emplace_back(Pair("state",         tr->strState()));
+            arr.emplace_back(jtr);
         }
     }
     return arr;
@@ -123,13 +124,11 @@ Value dxGetTransactionsHistory(const Array & params, bool fHelp)
 {
     bool invalidParams = ((params.size() != 0) &&
                           (params.size() != 1));
-    if (fHelp || invalidParams)
-    {
+    if (fHelp || invalidParams) {
         Object error;
         error.emplace_back(Pair("error",
-                                "dxGetTransactionsHistory\n"
-                                "(ALL - optional parameter, if specified then all transactions are shown, "
-                                "not only successfully completed "));
+                                "Invalid number of parameters"));
+        error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
         return  error;
 
     }
@@ -141,30 +140,27 @@ Value dxGetTransactionsHistory(const Array & params, bool fHelp)
         trlist = XBridgeApp::m_historicTransactions;
     }
     {        
-        if(trlist.empty())
-        {
+        if(trlist.empty()) {
             LOG() << "empty history transactions list ";
             return arr;
         }
 
-        for (const auto &trEntry : trlist)
-        {
+        for (const auto &trEntry : trlist) {
             Object buy;
             const auto &tr = trEntry.second;
-            if(!isShowAll && tr->state != XBridgeTransactionDescr::trFinished)
-            {
+            if(!isShowAll && tr->state != XBridgeTransactionDescr::trFinished) {
                 continue;
             }
             double fromAmount = static_cast<double>(tr->fromAmount);
             double toAmount = static_cast<double>(tr->toAmount);
             double price = fromAmount / toAmount;
             std::string buyTime = to_simple_string(tr->created);
-            buy.push_back(Pair("time",      buyTime));
-            buy.push_back(Pair("traid_id",  tr->id.GetHex()));
-            buy.push_back(Pair("price",     price));
-            buy.push_back(Pair("size",      tr->toAmount));
-            buy.push_back(Pair("side",      "buy"));
-            arr.push_back(buy);
+            buy.emplace_back(Pair("time",      buyTime));
+            buy.emplace_back(Pair("traid_id",  tr->id.GetHex()));
+            buy.emplace_back(Pair("price",     price));
+            buy.emplace_back(Pair("size",      tr->toAmount));
+            buy.emplace_back(Pair("side",      "buy"));
+            arr.emplace_back(buy);
         }
     }
     return arr;
@@ -173,12 +169,11 @@ Value dxGetTransactionsHistory(const Array & params, bool fHelp)
 Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp)
 {
 
-    if (fHelp || (params.size() != 4 && params.size() != 5))
-    {
+    if (fHelp || (params.size() != 4 && params.size() != 5)) {
         Object error;
-        error.push_back(Pair("error",
-                             "invalid parameters: dxGetTradeHistory "
-                             "(from currency) (to currency) (start time) (end time) (txids - optional) "));
+        error.emplace_back(Pair("error",
+                                "Invalid number of parameters"));
+        error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
         return  error;
     }
 
@@ -190,8 +185,7 @@ Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp)
     }
     {
 
-        if(trlist.empty())
-        {
+        if(trlist.empty()) {
             LOG() << "empty history transactions list";
             return arr;
         }
@@ -200,8 +194,7 @@ Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp)
         const auto startTimeFrame   = params[2].get_int();
         const auto endTimeFrame     = params[3].get_int();
         bool isShowTxids = false;
-        if(params.size() == 5)
-        {
+        if(params.size() == 5) {
             isShowTxids = (params[4].get_str() == "txids");
         }
 
@@ -210,7 +203,7 @@ Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp)
 
         //copy all transactions between startTimeFrame and endTimeFrame
         std::copy_if(trlist.begin(), trlist.end(), std::inserter(trList, trList.end()),
-                     [&startTimeFrame, &endTimeFrame, &toCurrency, &fromCurrency](const TransactionPair &transaction){
+                     [&startTimeFrame, &endTimeFrame, &toCurrency, &fromCurrency](const TransactionPair &transaction) {
             return  ((transaction.second->created)      <   bpt::from_time_t(endTimeFrame)) &&
                     ((transaction.second->created)      >   bpt::from_time_t(startTimeFrame)) &&
                     (transaction.second->toCurrency     ==  toCurrency) &&
@@ -222,32 +215,25 @@ Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp)
             LOG() << "No transactions for the specified period " << __FUNCTION__;
             return  arr;
         }
-
         RealVector toAmounts;
         RealVector fromAmounts;
-
         Object res;
-
         Array times;
         times.emplace_back(startTimeFrame);
         times.emplace_back(endTimeFrame);
         res.emplace_back(Pair("t", times));
 
         //copy values into vector
-        for (const auto &trEntry : trList)
-        {
+        for (const auto &trEntry : trList) {
             const auto &tr          = trEntry.second;
             const auto fromAmount   = xBridgeValueFromAmount(tr->fromAmount);
             const auto toAmount     = xBridgeValueFromAmount(tr->toAmount);
             toAmounts.emplace_back(toAmount);
             fromAmounts.emplace_back(fromAmount);
-            trVector.push_back(tr);
+            trVector.emplace_back(tr);
         }
-
-
         std::sort(trVector.begin(), trVector.end(),
-                  [](const XBridgeTransactionDescrPtr &a,  const XBridgeTransactionDescrPtr &b)
-        {
+                  [](const XBridgeTransactionDescrPtr &a,  const XBridgeTransactionDescrPtr &b) {
              return (a->created) < (b->created);
         });
 
@@ -281,11 +267,9 @@ Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp)
         lows.emplace_back(*std::min_element(fromAmounts.begin(), fromAmounts.end()));
         res.emplace_back(Pair("l", lows));
 
-        if(isShowTxids)
-        {
+        if(isShowTxids) {
             Array tmp;
-            for(auto tr : trVector)
-            {
+            for(const auto &tr : trVector) {
                 tmp.emplace_back(tr->id.GetHex());
             }
             res.emplace_back(Pair("txids", tmp));
@@ -305,8 +289,10 @@ Value dxGetTransactionInfo(const Array & params, bool fHelp)
 {
     if (fHelp || params.size() != 1) {
         Object error;
-        error.push_back(Pair("error",
-                             "invalid parameters: dxGetTransactionInfo (id)\nTransaction info"));
+        error.emplace_back(Pair("error",
+                                "Invalid number of parameters"));
+        error.emplace_back(Pair("code",
+                                xbridge::INVALID_PARAMETERS));
         return  error;
     }
 
@@ -315,57 +301,54 @@ Value dxGetTransactionInfo(const Array & params, bool fHelp)
     // pending tx
     {
         boost::mutex::scoped_lock l(XBridgeApp::m_txLocker);
-        if(XBridgeApp::m_pendingTransactions.count(uint256(id)))
-        {
+        if(XBridgeApp::m_pendingTransactions.count(uint256(id))) {
             const auto &tr = XBridgeApp::m_pendingTransactions[id];
             Object jtr;
-            jtr.push_back(Pair("id",            tr->id.GetHex()));
-            jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",   tr->from));
-            jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
-            jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",     tr->to));
-            jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
-            jtr.push_back(Pair("state",         tr->strState()));
-            arr.push_back(jtr);
+            jtr.emplace_back(Pair("id",            tr->id.GetHex()));
+            jtr.emplace_back(Pair("from",          tr->fromCurrency));
+            jtr.emplace_back(Pair("fromAddress",   tr->from));
+            jtr.emplace_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
+            jtr.emplace_back(Pair("to",            tr->toCurrency));
+            jtr.emplace_back(Pair("toAddress",     tr->to));
+            jtr.emplace_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
+            jtr.emplace_back(Pair("state",         tr->strState()));
+            arr.emplace_back(jtr);
         }
     }
 
     // active tx
     {
         boost::mutex::scoped_lock l(XBridgeApp::m_txLocker);
-        if(XBridgeApp::m_transactions.count(id))
-        {
+        if(XBridgeApp::m_transactions.count(id)) {
             const auto &tr = XBridgeApp::m_transactions[id];
             Object jtr;
-            jtr.push_back(Pair("id",            tr->id.GetHex()));
-            jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",   tr->from));
-            jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
-            jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",     tr->to));
-            jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
-            jtr.push_back(Pair("state",         tr->strState()));
-            arr.push_back(jtr);
+            jtr.emplace_back(Pair("id",            tr->id.GetHex()));
+            jtr.emplace_back(Pair("from",          tr->fromCurrency));
+            jtr.emplace_back(Pair("fromAddress",   tr->from));
+            jtr.emplace_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
+            jtr.emplace_back(Pair("to",            tr->toCurrency));
+            jtr.emplace_back(Pair("toAddress",     tr->to));
+            jtr.emplace_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
+            jtr.emplace_back(Pair("state",         tr->strState()));
+            arr.emplace_back(jtr);
         }
     }
 
     // historic tx
     {
         boost::mutex::scoped_lock l(XBridgeApp::m_txLocker);
-        if(XBridgeApp::m_historicTransactions.count(id))
-        {
+        if(XBridgeApp::m_historicTransactions.count(id)) {
             const auto &tr = XBridgeApp::m_historicTransactions[id];
             Object jtr;
-            jtr.push_back(Pair("id",            tr->id.GetHex()));
-            jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",   tr->from));
-            jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
-            jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",     tr->to));
-            jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
-            jtr.push_back(Pair("state",         tr->strState()));
-            arr.push_back(jtr);
+            jtr.emplace_back(Pair("id",            tr->id.GetHex()));
+            jtr.emplace_back(Pair("from",          tr->fromCurrency));
+            jtr.emplace_back(Pair("fromAddress",   tr->from));
+            jtr.emplace_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
+            jtr.emplace_back(Pair("to",            tr->toCurrency));
+            jtr.emplace_back(Pair("toAddress",     tr->to));
+            jtr.emplace_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
+            jtr.emplace_back(Pair("state",         tr->strState()));
+            arr.emplace_back(jtr);
         }
     }
     return arr;
@@ -376,20 +359,19 @@ Value dxGetTransactionInfo(const Array & params, bool fHelp)
 //******************************************************************************
 Value dxGetCurrencies(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() > 0)
-    {
+    if (fHelp || params.size() > 0) {
         Object error;
-        error.push_back(Pair("error",
-                             "invalid parameters: dxGetCurrencies\nList currencies."));
+        error.emplace_back(Pair("error",
+                                "This function does not accept any parameter"));
+        error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
         return  error;
     }
 
     Object obj;
 
     std::vector<std::string> currencies = XBridgeApp::instance().sessionsCurrencies();
-    for (std::string currency : currencies)
-    {
-        obj.push_back(Pair(currency, ""));
+    for (std::string currency : currencies) {
+        obj.emplace_back(Pair(currency, ""));
     }
     return obj;
 }
@@ -398,14 +380,12 @@ Value dxGetCurrencies(const Array & params, bool fHelp)
 //******************************************************************************
 Value dxCreateTransaction(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() != 6)
-    {
+    if (fHelp || params.size() != 6) {
         Object error;
-        error.push_back(Pair("error",
-                             "invalid parameters: dxCreateTransaction "
-                             "(address from) (currency from) (amount from) "
-                             "(address to) (currency to) (amount to)\n"
-                             "Create xbridge transaction."));
+        error.emplace_back(Pair("error",
+                                "Invalid number of parameters"));
+        error.emplace_back(Pair("code",
+                                xbridge::INVALID_PARAMETERS));
         return  error;
     }
 
@@ -417,10 +397,10 @@ Value dxCreateTransaction(const Array & params, bool fHelp)
     double      toAmount        = params[5].get_real();
 
     if ((from.size() < 32 && from.size() > 36) ||
-            (to.size() < 32 && to.size() > 36))
-    {
+            (to.size() < 32 && to.size() > 36)) {
         Object error;
-        error.push_back(Pair("error", "incorrect address."));
+        error.emplace_back(Pair("error", "Incorrect address"));
+        error.emplace_back(Pair("code", xbridge::INVALID_ADDRESS));
         return  error;
     }
 
@@ -429,19 +409,19 @@ Value dxCreateTransaction(const Array & params, bool fHelp)
           (from, fromCurrency, xBridgeAmountFromReal(fromAmount),
            to, toCurrency, xBridgeAmountFromReal(toAmount), id);
 
-    if(res == xbridge::SUCCESS)
-    {
+    if(res == xbridge::SUCCESS) {
         Object obj;
-        obj.push_back(Pair("from", from));
-        obj.push_back(Pair("fromCurrency", fromCurrency));
-        obj.push_back(Pair("fromAmount", fromAmount));
-        obj.push_back(Pair("to", to));
-        obj.push_back(Pair("toCurrency", toCurrency));
-        obj.push_back(Pair("toAmount", toAmount));
+        obj.emplace_back(Pair("from",           from));
+        obj.emplace_back(Pair("fromCurrency",   fromCurrency));
+        obj.emplace_back(Pair("fromAmount",     fromAmount));
+        obj.emplace_back(Pair("to",             to));
+        obj.emplace_back(Pair("toCurrency",     toCurrency));
+        obj.emplace_back(Pair("toAmount",       toAmount));
         return obj;
     } else {
         Object error;
         error.emplace_back(Pair("error", xbridge::xbridgeErrorText(res)));
+        error.emplace_back(Pair("code", res));
         return error;
     }
 }
@@ -450,13 +430,11 @@ Value dxCreateTransaction(const Array & params, bool fHelp)
 //******************************************************************************
 Value dxAcceptTransaction(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() != 3)
-    {
+    if (fHelp || params.size() != 3) {
         Object error;
-        error.push_back(Pair("error",
-                             "invalid parameters: dxAcceptTransaction (id) "
-                             "(address from) (address to)\n"
-                             "Accept xbridge transaction."));
+        error.emplace_back(Pair("error",
+                                "Invalid number of parameters"));
+        error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
         return  error;
     }
 
@@ -465,11 +443,11 @@ Value dxAcceptTransaction(const Array & params, bool fHelp)
     std::string toAddress      = params[2].get_str();
 
     if ((fromAddress.size() < 32 && fromAddress.size() > 36) ||
-            (toAddress.size() < 32 && toAddress.size() > 36))
-    {
+            (toAddress.size() < 32 && toAddress.size() > 36)) {
         Object error;
-        error.push_back(Pair("error",
-                             "incorrect address"));
+        error.emplace_back(Pair("error",
+                                "incorrect address"));
+        error.emplace_back(Pair("code", xbridge::INVALID_ADDRESS));
         return  error;
     }
 
@@ -478,14 +456,16 @@ Value dxAcceptTransaction(const Array & params, bool fHelp)
     const auto error = XBridgeApp::instance().acceptXBridgeTransaction(id, fromAddress, toAddress, idResult);
     if(error == xbridge::SUCCESS) {
         Object obj;
-        obj.push_back(Pair("status", "Accepted"));
-        obj.push_back(Pair("id",    id.GetHex()));
-        obj.push_back(Pair("from",  fromAddress));
-        obj.push_back(Pair("to",    toAddress));
+        obj.emplace_back(Pair("status", "Accepted"));
+        obj.emplace_back(Pair("id",     id.GetHex()));
+        obj.emplace_back(Pair("from",   fromAddress));
+        obj.emplace_back(Pair("to",     toAddress));
         return obj;
     } else {
         Object obj;
-        obj.push_back(Pair("error", xbridge::xbridgeErrorText(error)));
+        obj.emplace_back(Pair("error",
+                              xbridge::xbridgeErrorText(error)));
+        obj.emplace_back(Pair("code", error));
         return obj;
     }
 
@@ -495,24 +475,24 @@ Value dxAcceptTransaction(const Array & params, bool fHelp)
 //******************************************************************************
 Value dxCancelTransaction(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-    {
+    if (fHelp || params.size() != 1) {
         Object error;
-        error.push_back(Pair("error", "invalid parameters: dxCancelTransaction (id)\n"
-                                      "Cancel xbridge transaction."));
+        error.emplace_back(Pair("error",
+                                "Invalid number of parameters"));
+        error.emplace_back(Pair("code", xbridge::INVALID_ADDRESS));
         return  error;
     }
     LOG() << "rpc cancel transaction " << __FUNCTION__;
     uint256 id(params[0].get_str());
     const auto res = XBridgeApp::instance().cancelXBridgeTransaction(id, crRpcRequest);
-    if(res == xbridge::SUCCESS)
-    {
+    if(res == xbridge::SUCCESS) {
         Object obj;
-        obj.push_back(Pair("id",id.GetHex()));
+        obj.emplace_back(Pair("id", id.GetHex()));
         return  obj;
     } else {
         Object obj;
-        obj.push_back(Pair("error", xbridge::xbridgeErrorText(res)));
+        obj.emplace_back(Pair("error", xbridge::xbridgeErrorText(res)));
+        obj.emplace_back(Pair("code", res));
         return obj;
     }
 }
@@ -521,26 +501,25 @@ Value dxCancelTransaction(const Array & params, bool fHelp)
 //******************************************************************************
 json_spirit::Value dxrollbackTransaction(const json_spirit::Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-    {
+    if (fHelp || params.size() != 1) {
         Object error;
-        error.push_back(Pair("error",
-                             "invalid parameters: dxrollbackTransaction (id)\n"
-                             "Rollback xbridge transaction."));
+        error.emplace_back(Pair("error",
+                                "Invalid number of parameters"));
+        error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
         return  error;
     }
     LOG() << "rpc rollback transaction " << __FUNCTION__;
     uint256 id(params[0].get_str());
     const auto res = XBridgeApp::instance().rollbackXBridgeTransaction(id);
 
-    if(res == xbridge::SUCCESS)
-    {
+    if(res == xbridge::SUCCESS) {
         Object obj;
-        obj.push_back(Pair("id",id.GetHex()));
+        obj.emplace_back(Pair("id", id.GetHex()));
         return  obj;
     } else {
         Object obj;
-        obj.push_back(Pair("error", xbridge::xbridgeErrorText(res)));
+        obj.emplace_back(Pair("error", xbridge::xbridgeErrorText(res)));
+        obj.emplace_back(Pair("code", res));
         return obj;
     }
 }
@@ -549,13 +528,12 @@ json_spirit::Value dxrollbackTransaction(const json_spirit::Array& params, bool 
 //******************************************************************************
 json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
 {
-    if (fHelp || (params.size() != 3 && params.size() != 4))
-    {
+    if (fHelp || (params.size() != 3 && params.size() != 4)) {
         Object error;
-        error.push_back(Pair("error",
-                             "invalid parameters: dxGetOrderBook "
-                             "(the level of detail) (from currency) (to currency) "
-                             "(max orders - optional, default = 50) "));
+        error.emplace_back(Pair("error",
+                                "Invalid number of parameters"));
+        error.emplace_back(Pair("code",
+                                xbridge::INVALID_PARAMETERS));
         return  error;
     }
 
@@ -566,8 +544,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
         trList = XBridgeApp::m_pendingTransactions;
     }
     {
-        if(trList.empty())
-        {
+        if(trList.empty()) {
             LOG() << "empty  transactions list ";
             return arr;
         }
@@ -586,22 +563,19 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
         const auto toCurrency   = params[2].get_str();
 
         std::size_t maxOrders = 50;
-        if(detailLevel == 2 && params.size() == 4)
-        {
+        if(detailLevel == 2 && params.size() == 4) {
             maxOrders = params[3].get_int();;
         }
 
         //copy all transactions
         std::copy_if(trList.begin(), trList.end(), std::inserter(asksList, asksList.end()),
-                     [&toCurrency, &fromCurrency](const TransactionPair &transaction)
-        {
+                     [&toCurrency, &fromCurrency](const TransactionPair &transaction) {
             return  ((transaction.second->toCurrency == fromCurrency) &&
                     (transaction.second->fromCurrency == toCurrency));
         });
 
         std::copy_if(trList.begin(), trList.end(), std::inserter(bidsList, bidsList.end()),
-                     [&toCurrency, &fromCurrency](const TransactionPair &transaction)
-        {
+                     [&toCurrency, &fromCurrency](const TransactionPair &transaction) {
             return  ((transaction.second->toCurrency == toCurrency) &&
                     (transaction.second->fromCurrency == fromCurrency));
         });
@@ -625,8 +599,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
             //return Only the best bid and ask
 
             const auto bidsItem = std::max_element(bidsList.begin(), bidsList.end(),
-                                       [](const TransactionPair &a, const TransactionPair &b)
-            {
+                                       [](const TransactionPair &a, const TransactionPair &b) {
                 //find transaction with best bids
                 const auto &tr1 = a.second;
                 const auto &tr2 = b.second;
@@ -645,8 +618,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
             ///////////////////////////////////////////////////////////////////////////////////////////////
 
             const auto asksItem = std::min_element(asksList.begin(), asksList.end(),
-                                                   [](const TransactionPair &a, const TransactionPair &b)
-            {
+                                                   [](const TransactionPair &a, const TransactionPair &b) {
                 //find transactions with best asks
                 const auto &tr1 = a.second;
                 const auto &tr2 = b.second;
@@ -671,21 +643,19 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
             std::vector<XBridgeTransactionDescrPtr> asksVector;
             std::vector<XBridgeTransactionDescrPtr> bidsVector;
 
-            for (const auto &trEntry : asksList)
-            {
+            for (const auto &trEntry : asksList) {
                 const auto &tr = trEntry.second;
-                asksVector.push_back(tr);
+                asksVector.emplace_back(tr);
             }
 
-            for (const auto &trEntry : bidsList)
-            {
+            for (const auto &trEntry : bidsList) {
                 const auto &tr = trEntry.second;
-                bidsVector.push_back(tr);
+                bidsVector.emplace_back(tr);
             }
 
             //sort descending
-            std::sort(bidsVector.begin(), bidsVector.end(), [](const XBridgeTransactionDescrPtr &a,  const XBridgeTransactionDescrPtr &b)
-            {
+            std::sort(bidsVector.begin(), bidsVector.end(),
+                      [](const XBridgeTransactionDescrPtr &a,  const XBridgeTransactionDescrPtr &b) {
                 const auto priceA = xBridgeValueFromAmount(a->fromAmount) / xBridgeValueFromAmount(a->toAmount);
                 const auto priceB = xBridgeValueFromAmount(b->fromAmount) / xBridgeValueFromAmount(b->toAmount);
                 return priceA > priceB;
@@ -701,8 +671,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
              * @brief bound - calculate upper bound
              */
             auto bound = std::min(maxOrders, bidsVector.size());
-            for(size_t i = 0; i < bound; i++)
-            {
+            for(size_t i = 0; i < bound; i++) {
                 Array tmp;
                 //calculate bids and push to array
                 const auto bidPrice = xBridgeValueFromAmount(bidsVector[i]->fromAmount) / xBridgeValueFromAmount(bidsVector[i]->toAmount);
@@ -712,8 +681,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
                 bids.emplace_back(tmp);
             }
             bound = std::min(maxOrders, asksVector.size());
-            for(size_t  i = 0; i < bound; i++ )
-            {
+            for(size_t  i = 0; i < bound; i++ ) {
                 Array tmp;
                 //calculate asks and push to array
                 const auto askPrice = xBridgeValueFromAmount(asksVector[i]->fromAmount) / xBridgeValueFromAmount(asksVector[i]->toAmount);
@@ -728,8 +696,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
         {
             //Full order book (non aggregated)
 
-            for (const auto &trEntry : bidsList)
-            {
+            for (const auto &trEntry : bidsList) {
                 const auto &tr = trEntry.second;
                 Array tmp;
                 const auto bidPrice = xBridgeValueFromAmount(tr->fromAmount) / xBridgeValueFromAmount(tr->toAmount);
@@ -738,8 +705,7 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
                 tmp.emplace_back(xBridgeValueFromAmount(tr->fromAmount));
                 bids.emplace_back(tmp);
             }
-            for (const auto &trEntry : asksList)
-            {
+            for (const auto &trEntry : asksList) {
                 const auto &tr = trEntry.second;
                 Array tmp;
                 const auto askPrice = xBridgeValueFromAmount(tr->fromAmount) / xBridgeValueFromAmount(tr->toAmount);
@@ -753,9 +719,10 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
         default:
             LOG() << "invalid detail level value: " << detailLevel << ", " << __FUNCTION__;
             Object error;
-            error.emplace_back(Pair("error", "invalid detail level value:"));
+            error.emplace_back(Pair("error",
+                                    "invalid detail level value:"));
+            error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
             return  error;
-
         }
         res.emplace_back(Pair("bids", bids));
         res.emplace_back(Pair("asks", asks));

--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -78,10 +78,10 @@ Value dxGetTransactions(const Array & params, bool fHelp)
             const auto tr = trEntry.second;
             jtr.push_back(Pair("id",            tr->id.GetHex()));
             jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",  tr->from));
+            jtr.push_back(Pair("fromAddress",   tr->from));
             jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
             jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",    tr->to));
+            jtr.push_back(Pair("toAddress",     tr->to));
             jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
             jtr.push_back(Pair("state",         tr->strState()));
             arr.push_back(jtr);
@@ -101,10 +101,10 @@ Value dxGetTransactions(const Array & params, bool fHelp)
             const auto &tr = trEntry.second;
             jtr.push_back(Pair("id",            tr->id.GetHex()));
             jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",  tr->from));
+            jtr.push_back(Pair("fromAddress",   tr->from));
             jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
             jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",    tr->to));
+            jtr.push_back(Pair("toAddress",     tr->to));
             jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
             jtr.push_back(Pair("state",         tr->strState()));
             arr.push_back(jtr);
@@ -312,10 +312,10 @@ Value dxGetTransactionInfo(const Array & params, bool fHelp)
             Object jtr;
             jtr.push_back(Pair("id",            tr->id.GetHex()));
             jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",  tr->from));
+            jtr.push_back(Pair("fromAddress",   tr->from));
             jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
             jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",    tr->to));
+            jtr.push_back(Pair("toAddress",     tr->to));
             jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
             jtr.push_back(Pair("state",         tr->strState()));
             arr.push_back(jtr);
@@ -331,10 +331,10 @@ Value dxGetTransactionInfo(const Array & params, bool fHelp)
             Object jtr;
             jtr.push_back(Pair("id",            tr->id.GetHex()));
             jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",  tr->from));
+            jtr.push_back(Pair("fromAddress",   tr->from));
             jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
             jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",    tr->to));
+            jtr.push_back(Pair("toAddress",     tr->to));
             jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
             jtr.push_back(Pair("state",         tr->strState()));
             arr.push_back(jtr);
@@ -350,10 +350,10 @@ Value dxGetTransactionInfo(const Array & params, bool fHelp)
             Object jtr;
             jtr.push_back(Pair("id",            tr->id.GetHex()));
             jtr.push_back(Pair("from",          tr->fromCurrency));
-            jtr.push_back(Pair("fromAddress",  tr->from));
+            jtr.push_back(Pair("fromAddress",   tr->from));
             jtr.push_back(Pair("fromAmount",    xBridgeValueFromAmount(tr->fromAmount)));
             jtr.push_back(Pair("to",            tr->toCurrency));
-            jtr.push_back(Pair("toAddress",    tr->to));
+            jtr.push_back(Pair("toAddress",     tr->to));
             jtr.push_back(Pair("toAmount",      xBridgeValueFromAmount(tr->toAmount)));
             jtr.push_back(Pair("state",         tr->strState()));
             arr.push_back(jtr);
@@ -517,7 +517,8 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
     if (fHelp || (params.size() != 3 && params.size() != 4))
     {
         throw runtime_error("dxGetOrderBook "
-                            "(the level of detail) (from currency) (to currency) (max orders - optional, default = 50) ");
+                            "(the level of detail) (from currency) (to currency) "
+                            "(max orders - optional, default = 50) ");
     }
 
     Array arr;

--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -201,10 +201,9 @@ Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp)
         const auto toCurrency       = params[1].get_str();
         const auto startTimeFrame   = params[2].get_int();
         const auto endTimeFrame     = params[3].get_int();
-        bool isShowTxids = false;
-        if(params.size() == 5) {
-            isShowTxids = (params[4].get_str() == "txids");
-        }
+
+        bool isShowTxids = (params.size() == 5) && (params[4].get_str() == "txids");
+
 
         TransactionMap trList;
         std::vector<XBridgeTransactionDescrPtr> trVector;

--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -58,8 +58,10 @@ uint64_t xBridgeAmountFromReal(double val)
 
 Value dxGetTransactions(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() > 0)
-    {
+    if(fHelp) {
+        throw runtime_error("dxGetTransactions\nList transactions.");
+    }
+    if (params.size() > 0) {
         Object error;
         error.emplace_back(Pair("error",
                                 "This function does not accept any parameter"));
@@ -76,8 +78,7 @@ Value dxGetTransactions(const Array & params, bool fHelp)
             boost::mutex::scoped_lock l(XBridgeApp::m_txLocker);
             trlist = XBridgeApp::m_pendingTransactions;
         }
-        for (const auto & trEntry : trlist)
-        {
+        for (const auto & trEntry : trlist) {
             Object jtr;
             const auto tr = trEntry.second;
             jtr.emplace_back(Pair("id",            tr->id.GetHex()));
@@ -99,8 +100,7 @@ Value dxGetTransactions(const Array & params, bool fHelp)
             boost::mutex::scoped_lock l(XBridgeApp::m_txLocker);
             trlist = XBridgeApp::m_transactions;
         }
-        for (const auto &trEntry : trlist)
-        {
+        for (const auto &trEntry : trlist) {
             Object jtr;
             const auto &tr = trEntry.second;
             jtr.emplace_back(Pair("id",            tr->id.GetHex()));
@@ -122,15 +122,19 @@ Value dxGetTransactions(const Array & params, bool fHelp)
 
 Value dxGetTransactionsHistory(const Array & params, bool fHelp)
 {
+    if (fHelp) {
+        throw runtime_error("dxGetTransactionsHistory "
+                            "(ALL - optional parameter, if specified then all transactions are shown, "
+                            "not only successfully completed ");
+    }
     bool invalidParams = ((params.size() != 0) &&
                           (params.size() != 1));
-    if (fHelp || invalidParams) {
+    if (invalidParams) {
         Object error;
         error.emplace_back(Pair("error",
                                 "Invalid number of parameters"));
         error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
         return  error;
-
     }
     bool isShowAll = params.size() == 1 && params[0].get_str() == "ALL";
     Array arr;
@@ -169,7 +173,11 @@ Value dxGetTransactionsHistory(const Array & params, bool fHelp)
 Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp)
 {
 
-    if (fHelp || (params.size() != 4 && params.size() != 5)) {
+    if (fHelp) {
+        throw runtime_error("dxGetTradeHistory "
+                            "(from currency) (to currency) (start time) (end time) (txids - optional) ");
+    }
+    if ((params.size() != 4 && params.size() != 5)) {
         Object error;
         error.emplace_back(Pair("error",
                                 "Invalid number of parameters"));
@@ -287,12 +295,14 @@ Value dxGetTradeHistory(const json_spirit::Array& params, bool fHelp)
 
 Value dxGetTransactionInfo(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() != 1) {
+    if (fHelp) {
+         throw runtime_error("dxGetTransactionInfo (id) Transaction info.");
+    }
+    if (params.size() != 1) {
         Object error;
         error.emplace_back(Pair("error",
                                 "Invalid number of parameters"));
-        error.emplace_back(Pair("code",
-                                xbridge::INVALID_PARAMETERS));
+        error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
         return  error;
     }
 
@@ -359,7 +369,10 @@ Value dxGetTransactionInfo(const Array & params, bool fHelp)
 //******************************************************************************
 Value dxGetCurrencies(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() > 0) {
+    if (fHelp) {
+        throw runtime_error("dxGetCurrencies\nList currencies.");
+    }
+    if (params.size() > 0) {
         Object error;
         error.emplace_back(Pair("error",
                                 "This function does not accept any parameter"));
@@ -380,12 +393,17 @@ Value dxGetCurrencies(const Array & params, bool fHelp)
 //******************************************************************************
 Value dxCreateTransaction(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() != 6) {
+    if (fHelp) {
+        throw runtime_error("dxCreateTransaction "
+                            "(address from) (currency from) (amount from) "
+                            "(address to) (currency to) (amount to)\n"
+                            "Create xbridge transaction.");
+    }
+    if (params.size() != 6) {
         Object error;
         error.emplace_back(Pair("error",
                                 "Invalid number of parameters"));
-        error.emplace_back(Pair("code",
-                                xbridge::INVALID_PARAMETERS));
+        error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
         return  error;
     }
 
@@ -430,7 +448,12 @@ Value dxCreateTransaction(const Array & params, bool fHelp)
 //******************************************************************************
 Value dxAcceptTransaction(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() != 3) {
+    if (fHelp) {
+        throw runtime_error("dxAcceptTransaction (id) "
+                            "(address from) (address to)\n"
+                            "Accept xbridge transaction.");
+    }
+    if (params.size() != 3) {
         Object error;
         error.emplace_back(Pair("error",
                                 "Invalid number of parameters"));
@@ -468,14 +491,17 @@ Value dxAcceptTransaction(const Array & params, bool fHelp)
         obj.emplace_back(Pair("code", error));
         return obj;
     }
-
 }
 
 //******************************************************************************
 //******************************************************************************
 Value dxCancelTransaction(const Array & params, bool fHelp)
 {
-    if (fHelp || params.size() != 1) {
+    if(fHelp) {
+        throw runtime_error("dxCancelTransaction (id)\n"
+                            "Cancel xbridge transaction.");
+    }
+    if (params.size() != 1) {
         Object error;
         error.emplace_back(Pair("error",
                                 "Invalid number of parameters"));
@@ -501,7 +527,11 @@ Value dxCancelTransaction(const Array & params, bool fHelp)
 //******************************************************************************
 json_spirit::Value dxrollbackTransaction(const json_spirit::Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1) {
+    if (fHelp) {
+        throw runtime_error("dxRollbackTransaction (id)\n"
+                            "Rollback xbridge transaction.");
+    }
+    if (params.size() != 1) {
         Object error;
         error.emplace_back(Pair("error",
                                 "Invalid number of parameters"));
@@ -528,7 +558,12 @@ json_spirit::Value dxrollbackTransaction(const json_spirit::Array& params, bool 
 //******************************************************************************
 json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
 {
-    if (fHelp || (params.size() != 3 && params.size() != 4)) {
+    if (fHelp) {
+        throw runtime_error("dxGetOrderBook "
+                            "(the level of detail) (from currency) (to currency) "
+                            "(max orders - optional, default = 50) ");
+    }
+    if ((params.size() != 3 && params.size() != 4)) {
         Object error;
         error.emplace_back(Pair("error",
                                 "Invalid number of parameters"));
@@ -562,12 +597,27 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
         const auto fromCurrency = params[1].get_str();
         const auto toCurrency   = params[2].get_str();
 
+        if (detailLevel < 1 || detailLevel > 3) {
+            Object error;
+            error.emplace_back(Pair("error",
+                                    "invalid detail level value:"));
+            error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
+            return  error;
+        }
+
         std::size_t maxOrders = 50;
         if(detailLevel == 2 && params.size() == 4) {
             maxOrders = params[3].get_int();;
         }
+        if(maxOrders < 1) {
+            Object error;
+            error.emplace_back(Pair("error",
+                                    "Negative value of maximum orders parameter"));
+            error.emplace_back(Pair("code", xbridge::INVALID_PARAMETERS));
+            return  error;
+        }
 
-        //copy all transactions
+        //copy all transactions in currencies specified in the parameters
         std::copy_if(trList.begin(), trList.end(), std::inserter(asksList, asksList.end()),
                      [&toCurrency, &fromCurrency](const TransactionPair &transaction) {
             return  ((transaction.second->toCurrency == fromCurrency) &&
@@ -597,7 +647,6 @@ json_spirit::Value dxGetOrderBook(const json_spirit::Array& params, bool fHelp)
         case 1:
         {
             //return Only the best bid and ask
-
             const auto bidsItem = std::max_element(bidsList.begin(), bidsList.end(),
                                        [](const TransactionPair &a, const TransactionPair &b) {
                 //find transaction with best bids

--- a/src/xbridge/util/xbridgeerror.cpp
+++ b/src/xbridge/util/xbridgeerror.cpp
@@ -1,21 +1,21 @@
 #include "xbridgeerror.h"
 namespace xbridge {
-    const std::string xbridgeErrorText(const Error error, const std::string &argumrnt)
+    const std::string xbridgeErrorText(const Error error, const std::string &argument)
     {
         switch (error)
         {
         case Error::INVALID_CURRENCY:
-            return "invalid currency " + argumrnt;
+            return "invalid currency " + argument;
         case Error::NO_SESSION:
-            return "no session for currency " + argumrnt;
+            return "no session for currency " + argument;
         case Error::INSIFFICIENT_FUNDS:
-            return "Insufficient funds for " + argumrnt;
+            return "Insufficient funds for " + argument;
         case Error::TRANSACTION_NOT_FOUND:
-            return "Transaction " + argumrnt + " not found";
+            return "Transaction " + argument + " not found";
         case Error::UNKNOWN_SESSION:
-            return "Unknown session for " + argumrnt;
+            return "Unknown session for " + argument;
         case Error::REVERT_TX_FAILED:
-            return "revert tx failed for "  + argumrnt;
+            return "revert tx failed for "  + argument;
         case Error::SUCCESS:
             return "";
         case Error::UNKNOWN_ERROR:
@@ -25,7 +25,7 @@ namespace xbridge {
         case Error::INVALID_PARAMETERS:
             return "";
         case Error::INVALID_AMOUNT:
-            return "invalid amount " + argumrnt;
+            return "invalid amount " + argument;
         }
         return "invalid error value";
     }

--- a/src/xbridge/util/xbridgeerror.cpp
+++ b/src/xbridge/util/xbridgeerror.cpp
@@ -20,6 +20,10 @@ namespace xbridge {
             return "";
         case Error::UNKNOWN_ERROR:
             return "unknown error";
+        case Error::INVALID_ADDRESS:
+            return "invalid address";
+        case Error::INVALID_PARAMETERS:
+            return "";
         case Error::INVALID_AMOUNT:
             return "invalid amount " + argumrnt;
         }

--- a/src/xbridge/util/xbridgeerror.h
+++ b/src/xbridge/util/xbridgeerror.h
@@ -26,6 +26,6 @@ namespace xbridge
      * @param argumrnt
      * @return
      */
-    const std::string xbridgeErrorText(const Error error, const std::string &argumrnt = "");
+    const std::string xbridgeErrorText(const Error error, const std::string &argument = "");
 }
 #endif // XBRIDGEERROR_H

--- a/src/xbridge/util/xbridgeerror.h
+++ b/src/xbridge/util/xbridgeerror.h
@@ -15,6 +15,8 @@ namespace xbridge
         UNKNOWN_SESSION,
         REVERT_TX_FAILED,
         INVALID_AMOUNT,
+        INVALID_PARAMETERS,
+        INVALID_ADDRESS,
         UNKNOWN_ERROR
     };
 

--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -567,9 +567,9 @@ bool XBridgeApp::sendPendingTransaction(XBridgeTransactionDescrPtr & ptr)
 //******************************************************************************
 //******************************************************************************
 xbridge::Error XBridgeApp::acceptXBridgeTransaction(const uint256 &id,
-                                             const std::string &from,
-                                             const std::string &to,
-                                             uint256 &result)
+                                                    const std::string &from,
+                                                    const std::string &to,
+                                                    uint256 &result)
 {
     XBridgeTransactionDescrPtr ptr;
     {

--- a/src/xbridge/xbridgeapp.h
+++ b/src/xbridge/xbridgeapp.h
@@ -74,9 +74,21 @@ public:
     xbridge::Error rollbackXBridgeTransaction(const uint256 &id);
     bool sendRollbackTransaction(const uint256 &txid);
 
+    /**
+     * @brief isValidAddress
+     * @param address
+     * @return
+     */
     bool isValidAddress(const std::string &address) const;
 
+    /**
+     * @brief validateAcceptParams
+     * @param id
+     * @param ptr
+     * @return
+     */
     xbridge::Error validateAcceptParams(const uint256 &id, XBridgeTransactionDescrPtr &ptr);
+
 
 public:
     bool stop();

--- a/src/xbridge/xbridgeapp.h
+++ b/src/xbridge/xbridgeapp.h
@@ -44,7 +44,7 @@ private:
     virtual ~XBridgeApp();
 
 public:
-    static XBridgeApp & instance();
+    static XBridgeApp &instance();
 
     static std::string version();
 
@@ -63,16 +63,20 @@ public:
 
     bool sendPendingTransaction(XBridgeTransactionDescrPtr &ptr);
 
-    xbridge::Error acceptXBridgeTransaction(const uint256 & id,
-                                     const std::string & from,
-                                     const std::string & to, uint256 &result);
-    bool sendAcceptingTransaction(XBridgeTransactionDescrPtr & ptr);
+    xbridge::Error acceptXBridgeTransaction(const uint256 &id,
+                                     const std::string &from,
+                                     const std::string &to, uint256 &result);
+    bool sendAcceptingTransaction(XBridgeTransactionDescrPtr &ptr);
 
-    xbridge::Error cancelXBridgeTransaction(const uint256 & id, const TxCancelReason & reason);
-    bool sendCancelTransaction(const uint256 & txid, const TxCancelReason & reason);
+    xbridge::Error cancelXBridgeTransaction(const uint256 &id, const TxCancelReason &reason);
+    bool sendCancelTransaction(const uint256 &txid, const TxCancelReason &reason);
 
-    xbridge::Error rollbackXBridgeTransaction(const uint256 & id);
-    bool sendRollbackTransaction(const uint256 & txid);
+    xbridge::Error rollbackXBridgeTransaction(const uint256 &id);
+    bool sendRollbackTransaction(const uint256 &txid);
+
+    bool isValidAddress(const std::string &address) const;
+
+    xbridge::Error validateAcceptParams(const uint256 &id, XBridgeTransactionDescrPtr &ptr);
 
 public:
     bool stop();

--- a/src/xbridge/xbridgeapp.h
+++ b/src/xbridge/xbridgeapp.h
@@ -75,21 +75,37 @@ public:
     bool sendRollbackTransaction(const uint256 &txid);
 
     /**
-     * @brief isValidAddress
-     * @param address
-     * @return
+     * @brief isValidAddress checks the correctness of the address
+     * @param address checked address
+     * @return true, if address valid
      */
     bool isValidAddress(const std::string &address) const;
 
     /**
-     * @brief validateAcceptParams
-     * @param id
-     * @param ptr
-     * @return
+     * @brief checkAcceptParams checks the correctness of the parameters
+     * @param id - id accepted transaction
+     * @param ptr - smart pointer to accepted transaction
+     * @return xbridge::SUCCESS, if all parameters valid
      */
-    xbridge::Error validateAcceptParams(const uint256 &id, XBridgeTransactionDescrPtr &ptr);
+    xbridge::Error checkAcceptParams(const uint256 &id, XBridgeTransactionDescrPtr &ptr);
 
+    /**
+     * @brief checkCreateParams - checks parameter needs to success created transaction
+     * @param fromCurrency - from currency
+     * @param toCurrency - to currency
+     * @param fromAmount -  amount
+     * @return xbridge::SUCCES, if all parameters valid
+     */
+    xbridge::Error checkCreateParams(const std::string &fromCurrency, const std::string &toCurrency, const uint64_t &fromAmount);
 
+    /**
+     * @brief checkAmount - checks wallet balance
+     * @param currency - currency name
+     * @param amount - amount
+     * @return xbridge::SUCCES, if  the session currency is open and
+     * on account has sufficient funds for operations
+     */
+    xbridge::Error checkAmount(const std::string &currency, const uint64_t &amount);
 public:
     bool stop();
 


### PR DESCRIPTION
Add optional validate parameter to dxCreate and dxAccept.
When set to true, the order would not be sent to the market, but would check that it contains all valid information. This feature would be useful when testing trading bots.
