### PR TITLE
Fix servicenode start states

### DIFF
--- a/src/activeservicenode.cpp
+++ b/src/activeservicenode.cpp
@@ -19,6 +19,9 @@ void CActiveServicenode::ManageStatus()
 
     if (fDebug) LogPrintf("CActiveServicenode::ManageStatus() - Begin\n");
 
+    // If state is set to true, servicenode ping will be sent regardless of last occurrence.
+    bool forceSendPing = false;
+
     //need correct blocks to send ping
     if (Params().NetworkID() != CBaseChainParams::REGTEST && !servicenodeSync.IsBlockchainSynced()) {
         status = ACTIVE_SERVICENODE_SYNC_IN_PROCESS;
@@ -33,7 +36,10 @@ void CActiveServicenode::ManageStatus()
         pmn = mnodeman.Find(pubKeyServicenode);
         if (pmn != NULL) {
             pmn->Check();
-            if (pmn->IsEnabled() && pmn->protocolVersion == PROTOCOL_VERSION) EnableHotColdServiceNode(pmn->vin, pmn->addr);
+            if (pmn->IsEnabled() && pmn->protocolVersion == PROTOCOL_VERSION) {
+                forceSendPing = true;
+                EnableHotColdServiceNode(pmn->vin, pmn->addr);
+            }
         }
     }
 
@@ -129,7 +135,7 @@ void CActiveServicenode::ManageStatus()
     }
 
     //send to all peers
-    if (!SendServicenodePing(errorMessage)) {
+    if (!SendServicenodePing(errorMessage, forceSendPing)) {
         LogPrintf("CActiveServicenode::ManageStatus() - Error on Ping: %s\n", errorMessage);
     }
 }
@@ -152,7 +158,7 @@ std::string CActiveServicenode::GetStatus()
     }
 }
 
-bool CActiveServicenode::SendServicenodePing(std::string& errorMessage)
+bool CActiveServicenode::SendServicenodePing(std::string& errorMessage, bool force)
 {
     if (status != ACTIVE_SERVICENODE_STARTED) {
         errorMessage = "Servicenode is not in a running status";
@@ -178,7 +184,8 @@ bool CActiveServicenode::SendServicenodePing(std::string& errorMessage)
     // Update lastPing for our servicenode in Servicenode list
     CServicenode* pmn = mnodeman.Find(vin);
     if (pmn != NULL) {
-        if (pmn->IsPingedWithin(SERVICENODE_PING_SECONDS, mnp.sigTime)) {
+        // If we have a force send ping request, skip the time check here
+        if (!force && pmn->IsPingedWithin(SERVICENODE_PING_SECONDS, mnp.sigTime)) {
             errorMessage = "Too early to send Servicenode Ping";
             return false;
         }
@@ -371,11 +378,14 @@ bool CActiveServicenode::GetServiceNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& se
 
 bool CActiveServicenode::GetServiceNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey, std::string strTxHash, std::string strOutputIndex)
 {
-    // Find possible candidates
-    TRY_LOCK(pwalletMain->cs_wallet, fWallet);
-    if (!fWallet) return false;
-
+    // Get servicenode coins
     vector<COutput> possibleCoins = SelectCoinsServicenode();
+    // If no coins return
+    if (possibleCoins.empty()) {
+        LogPrintf("CActiveServicenode::GetServiceNodeVin - No coins, could not locate valid vin\n");
+        return false;
+    }
+
     COutput* selectedOutput;
 
     // Find the vin
@@ -404,7 +414,7 @@ bool CActiveServicenode::GetServiceNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& se
         }
     } else {
         // No output specified,  Select the first one
-        if (possibleCoins.size() > 0) {
+        if (!possibleCoins.empty()) {
             selectedOutput = &possibleCoins[0];
         } else {
             LogPrintf("CActiveServicenode::GetServiceNodeVin - Could not locate specified vin from possible list\n");
@@ -453,6 +463,7 @@ vector<COutput> CActiveServicenode::SelectCoinsServicenode()
 
     // Temporary unlock MN coins from servicenode.conf
     if (GetBoolArg("-mnconflock", true)) {
+        LOCK(pwalletMain->cs_wallet);
         uint256 mnTxHash;
         BOOST_FOREACH (CServicenodeConfig::CServicenodeEntry mne, servicenodeConfig.getEntries()) {
             mnTxHash.SetHex(mne.getTxHash());
@@ -472,6 +483,7 @@ vector<COutput> CActiveServicenode::SelectCoinsServicenode()
 
     // Lock MN coins from servicenode.conf back if they where temporary unlocked
     if (!confLockedCoins.empty()) {
+        LOCK(pwalletMain->cs_wallet);
         BOOST_FOREACH (COutPoint outpoint, confLockedCoins)
             pwalletMain->LockCoin(outpoint);
     }

--- a/src/activeservicenode.cpp
+++ b/src/activeservicenode.cpp
@@ -144,7 +144,7 @@ std::string CActiveServicenode::GetStatus()
 {
     switch (status) {
     case ACTIVE_SERVICENODE_INITIAL:
-        return "Node just started, not yet activated";
+        return "Servicenode started, activation in progress...";
     case ACTIVE_SERVICENODE_SYNC_IN_PROCESS:
         return "Sync in progress. Must wait until sync is complete to start Servicenode";
     case ACTIVE_SERVICENODE_INPUT_TOO_NEW:
@@ -315,6 +315,10 @@ bool CActiveServicenode::Register(CTxIn vin, CService service, CKey keyCollatera
         LogPrintf("CActiveServicenode::Register() - %s\n", errorMessage);
         return false;
     }
+
+    // Assign the new vin
+    this->vin = vin;
+
     mnodeman.mapSeenServicenodeBroadcast.insert(make_pair(mnb.GetHash(), mnb));
     servicenodeSync.AddedServicenodeList(mnb.GetHash());
 

--- a/src/activeservicenode.h
+++ b/src/activeservicenode.h
@@ -30,8 +30,8 @@ private:
     // critical section to protect the inner data structures
     mutable CCriticalSection cs;
 
-    /// Ping Servicenode
-    bool SendServicenodePing(std::string& errorMessage);
+    /// Ping Servicenode with the option to force ping
+    bool SendServicenodePing(std::string& errorMessage, bool force = false);
 
     /// Register any Servicenode
     bool Register(CTxIn vin, CService service, CKey key, CPubKey pubKey, CKey keyServicenode, CPubKey pubKeyServicenode, std::string& errorMessage);

--- a/src/rpcservicenode.cpp
+++ b/src/rpcservicenode.cpp
@@ -14,6 +14,8 @@
 #include "servicenodeman.h"
 #include "rpcserver.h"
 #include "utilmoneystr.h"
+#include "tinyformat.h"
+#include "primitives/transaction.h"
 
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string.hpp>
@@ -291,12 +293,46 @@ Value servicenode(const Array& params, bool fHelp)
                 found = true;
                 std::string errorMessage;
 
-                bool result = activeServicenode.Register(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage);
+                CTransaction snodeTx;
+                uint256 snodeTxBlock;
+                GetTransaction(uint256S(mne.getTxHash()), snodeTx, snodeTxBlock, true);
+                int snodeTxIdx;
+                if (!snodeTx.IsNull() && mne.castOutputIndex(snodeTxIdx) && static_cast<int>(snodeTx.vout.size()) > snodeTxIdx) {
+                    CAmount snodeTxAmount = snodeTx.vout[snodeTxIdx].nValue;
+                    if (snodeTxAmount != SERVICENODE_REQUIRED_AMOUNT*COIN) {
+                        statusObj.push_back(Pair("result", "failed"));
+                        statusObj.push_back(Pair("errorMessage", strprintf("Servicenode input requires %d BLOCK. Only %f BLOCK was found",
+                                                         SERVICENODE_REQUIRED_AMOUNT, (float)snodeTxAmount/(float)COIN)));
+                        break;
+                    }
+                    // Check vin input age, make sure it's the minimum
+                    int age = 0;
+                    BlockMap::iterator mi = mapBlockIndex.find(snodeTxBlock);
+                    if (mi != mapBlockIndex.end() && (*mi).second) {
+                        CBlockIndex* pindex = (*mi).second;
+                        if (chainActive.Contains(pindex)) {
+                            age += chainActive.Height() - pindex->nHeight + 1;
+                        }
+                    }
+                    if (age < SERVICENODE_MIN_CONFIRMATIONS) {
+                        statusObj.push_back(Pair("result", "failed"));
+                        statusObj.push_back(Pair("errorMessage", strprintf("Servicenode input requires %d confirmations. It only has %d",
+                                                         SERVICENODE_MIN_CONFIRMATIONS, age)));
+                        break;
+                    }
 
-                statusObj.push_back(Pair("result", result ? "successful" : "failed"));
-                if (!result) {
-                    statusObj.push_back(Pair("errorMessage", errorMessage));
+                    activeServicenode.status = ACTIVE_SERVICENODE_INITIAL;
+                    bool result = activeServicenode.Register(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage);
+                    statusObj.push_back(Pair("result", result ? "successful" : "failed"));
+                    if (!result) {
+                        statusObj.push_back(Pair("errorMessage", errorMessage));
+                    }
+
+                } else {
+                    statusObj.push_back(Pair("result", "failed"));
+                    statusObj.push_back(Pair("errorMessage", "Servicenode input collateral is invalid."));
                 }
+
                 break;
             }
         }
@@ -351,13 +387,51 @@ Value servicenode(const Array& params, bool fHelp)
             if (strCommand == "start-missing" && pmn) continue;
             if (strCommand == "start-disabled" && pmn && pmn->IsEnabled()) continue;
 
-            bool result = activeServicenode.Register(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage);
+            // Lookup collateral transaction
+            CTransaction snodeTx;
+            uint256 snodeTxBlock;
+            GetTransaction(uint256S(mne.getTxHash()), snodeTx, snodeTxBlock, true);
+
+            bool success = !snodeTx.IsNull() && static_cast<int>(snodeTx.vout.size()) > nIndex;
+            if (success) {
+                // Verify required amount
+                CAmount snodeTxAmount = snodeTx.vout[nIndex].nValue;
+                if (snodeTxAmount != SERVICENODE_REQUIRED_AMOUNT * COIN) {
+                    success = false;
+                    errorMessage = strprintf("Servicenode input requires %d BLOCK. Only %f BLOCK was found",
+                                                       SERVICENODE_REQUIRED_AMOUNT, (float) snodeTxAmount / (float) COIN);
+                }
+                // Verify collateral input age
+                if (success) {
+                    // Check vin input age, make sure it's the minimum
+                    int age = 0;
+                    BlockMap::iterator mi = mapBlockIndex.find(snodeTxBlock);
+                    if (mi != mapBlockIndex.end() && (*mi).second) {
+                        CBlockIndex *pindex = (*mi).second;
+                        if (chainActive.Contains(pindex)) {
+                            age += chainActive.Height() - pindex->nHeight + 1;
+                        }
+                    }
+                    if (age < SERVICENODE_MIN_CONFIRMATIONS) {
+                        success = false;
+                        errorMessage = strprintf("Servicenode input requires %d confirmations. It only has %d",
+                                                           SERVICENODE_MIN_CONFIRMATIONS, age);
+                    }
+                }
+                // Register servicenode with network
+                if (success) {
+                    activeServicenode.status = ACTIVE_SERVICENODE_INITIAL;
+                    success = activeServicenode.Register(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage);
+                }
+            } else {
+                errorMessage = "Servicenode input collateral is invalid.";
+            }
 
             Object statusObj;
             statusObj.push_back(Pair("alias", mne.getAlias()));
-            statusObj.push_back(Pair("result", result ? "successful" : "failed"));
+            statusObj.push_back(Pair("result", success ? "successful" : "failed"));
 
-            if (result) {
+            if (success) {
                 successful++;
             } else {
                 failed++;

--- a/src/rpcservicenode.cpp
+++ b/src/rpcservicenode.cpp
@@ -444,7 +444,7 @@ Value servicenode(const Array& params, bool fHelp)
             mnObj.push_back(Pair("message", activeServicenode.GetStatus()));
             return mnObj;
         }
-        throw runtime_error("Servicenode not found\n");
+        throw runtime_error("Servicenode has not been verified by the network yet. This typically takes 5-10 minutes after start.\n");
     }
 
     if (strCommand == "winners") {


### PR DESCRIPTION
These changes fix state issues in servicenode `start-*` commands.

Summary of changes:
- Option to force send ping (useful when starting a servicenode)
- RPC commands now check confirmations, vin amounts, and set `activeServicenode` states to reduce discrepancies
- Now storing `vin` in `Register` (improves feedback on initial state)
- Better error messages