### PR TITLE
Fix geometry error on start

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -218,7 +218,6 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle* networkStyle, QWidget* parent) : QMai
 
     // Progress bar and label for blocks download
     progressBarLabel = new QLabel();
-    progressBarLabel->setVisible(true);
     progressBar = new GUIUtil::ProgressBar();
     progressBar->setAlignment(Qt::AlignCenter);
     progressBar->setVisible(true);


### PR DESCRIPTION
Fixes the setGeometry Qt error on start:
```
GUI: setGeometry: Unable to set geometry 5x13+640+300 on QWidgetWindow/'QLabelClassWindow'. Resulting geometry: 116x13+640+300 (frame: 8, 30, 8, 8, custom margin: 0, 0, 0, 0, minimum size: 0x0, maximum size: 16777215x16777215)
```