### PR TITLE
Add minimum xbridge protocol version requirement on relayed msgs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5575,7 +5575,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 LOCK(cs_vNodes);
                 for  (CNode * pnode : vNodes)
                 {
-                    if (pnode->setKnown.insert(hash).second)
+                    // Only relay to nodes with minimum protocol support version required by xbridge
+                    if (pnode->nVersion >= MIN_XBRIDGE_PROTOCOL_VERSION && pnode->setKnown.insert(hash).second)
                     {
                         pnode->PushMessage("xbridge", raw);
                     }

--- a/src/version.h
+++ b/src/version.h
@@ -12,7 +12,8 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70711;
+static const int PROTOCOL_VERSION = 70712;
+static const int MIN_XBRIDGE_PROTOCOL_VERSION = 70712;
 
 static const int SERVICENODE_WITH_XBRIDGE_INFO_PROTO_VERSION = 70711;
 

--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -401,7 +401,8 @@ void App::Impl::onSend(const std::vector<unsigned char> & id, const std::vector<
     LOCK(cs_vNodes);
     for  (CNode * pnode : vNodes)
     {
-        if (pnode->setKnown.insert(hash).second)
+        // Only relay to nodes with minimum protocol support version required by xbridge
+        if (pnode->nVersion >= MIN_XBRIDGE_PROTOCOL_VERSION && pnode->setKnown.insert(hash).second)
         {
             pnode->PushMessage("xbridge", msg);
         }


### PR DESCRIPTION
Clients with version less than 70712 do not support latest Xbridge packets. (Requires test & review)