### PR TITLE
Fixes order creation check for invalid values

### DIFF
--- a/src/qt/xbridgeui/xbridgetransactiondialog.cpp
+++ b/src/qt/xbridgeui/xbridgetransactiondialog.cpp
@@ -300,7 +300,9 @@ void XBridgeTransactionDialog::onSendTransaction()
 
     double fromAmount      = m_amountFrom->text().toDouble();
     double toAmount        = m_amountTo->text().toDouble();
-    if (fromAmount <= 0 || toAmount <= 0)
+    double minimumAmount   = 1.0 / boost::numeric_cast<double>(xbridge::TransactionDescr::COIN);
+
+    if (fromAmount < minimumAmount || toAmount < minimumAmount)
     {
         QMessageBox::warning(this, trUtf8("check parameters"), trUtf8("Invalid amount"));
         return;


### PR DESCRIPTION
Double precision variable can't be directly compared to 0 when doing amount checks, at least it should be compared to std::numeric_limits<double>::epsilon() because of precision problems. However, since we here have specific precision for a coin, that is now set as a limit.
