### PR TITLE
Validate address prefix against xbridge config

### DIFF
--- a/src/xbridge/xbridgewalletconnector.cpp
+++ b/src/xbridge/xbridgewalletconnector.cpp
@@ -60,14 +60,16 @@ double WalletConnector::getWalletBalance() const
  * If the specified wallet address has a valid prefix the method returns true, otherwise false.
  */
 bool WalletConnector::hasValidAddressPrefix(const std::string &addr) const {
-    if (addr.empty())
+    std::vector<unsigned char> decoded;
+    if (!DecodeBase58Check(addr, decoded))
+    {
         return false;
-    std::string addrChk = DecodeBase58(addr.c_str());
-    std::string prefix(addrChk.begin(), addrChk.begin()+2);
-    stringstream o1; o1 << std::hex << prefix;
-    int ah; o1 >> ah;
-    int ac = (int)addrPrefix[0];
-    return ah == ac;
+    }
+
+    bool isP2PKH = memcmp(addrPrefix,   &decoded[0], decoded.size()-sizeof(uint160)) == 0;
+    bool isP2SH  = memcmp(scriptPrefix, &decoded[0], decoded.size()-sizeof(uint160)) == 0;
+
+    return isP2PKH || isP2SH;
 }
 
 } // namespace xbridge

--- a/src/xbridge/xbridgewalletconnector.cpp
+++ b/src/xbridge/xbridgewalletconnector.cpp
@@ -3,6 +3,7 @@
 
 #include "xbridgewalletconnector.h"
 #include "xbridgetransactiondescr.h"
+#include "base58.h"
 
 //*****************************************************************************
 //*****************************************************************************
@@ -49,6 +50,24 @@ double WalletConnector::getWalletBalance() const
     }
 
     return amount;
+}
+
+/**
+ * \brief Checks if specified address has a valid prefix.
+ * \param addr Address to check
+ * \return returns true if address has a valid prefix, otherwise false.
+ *
+ * If the specified wallet address has a valid prefix the method returns true, otherwise false.
+ */
+bool WalletConnector::hasValidAddressPrefix(const std::string &addr) const {
+    if (addr.empty())
+        return false;
+    std::string addrChk = DecodeBase58(addr.c_str());
+    std::string prefix(addrChk.begin(), addrChk.begin()+2);
+    stringstream o1; o1 << std::hex << prefix;
+    int ah; o1 >> ah;
+    int ac = (int)addrPrefix[0];
+    return ah == ac;
 }
 
 } // namespace xbridge

--- a/src/xbridge/xbridgewalletconnector.h
+++ b/src/xbridge/xbridgewalletconnector.h
@@ -62,6 +62,7 @@ public:
 
 public:
     // helper functions
+    bool hasValidAddressPrefix(const std::string & addr) const;
 
     virtual bool isDustAmount(const double & amount) const = 0;
 


### PR DESCRIPTION
Compare the address prefix (version number) with the user specified address. This will prevent the situation where a user puts in the wrong coin address (or incompatible address).