### PR TITLE
Fix latest MacOS clang error boost/Qt, add QStyle header

### DIFF
--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -6,6 +6,7 @@
 #include "walletmodel.h"
 #include <QLineEdit>
 #include <QMessageBox>
+#include <QStyle>
 #include <boost/lexical_cast.hpp>
 
 using namespace std;


### PR DESCRIPTION
Included QStyle header ([QStyle is an abstract base class](http://doc.qt.io/qt-5/style-reference.html)) and the compiler no longer gives an error.  It is not clear whether the problem is with the compiler being more stringent or if the Qt version I'm using (5.11) no longer includes the QStyle header. 