### PR TITLE
feature-autotruncatelog: new configuration option, -autotruncatelog=<n>

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -82,6 +82,7 @@ BITCOIN_CORE_H = \
   addrman.h \
   alert.h \
   allocators.h \
+  autotruncatelog.h \
   amount.h \
   base58.h \
   bip38.h \
@@ -197,6 +198,7 @@ libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 libbitcoin_server_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS)
 libbitcoin_server_a_SOURCES = \
   addrman.cpp \
+  autotruncatelog.cpp \
   alert.cpp \
   bloom.cpp \
   chain.cpp \

--- a/src/autotruncatelog.cpp
+++ b/src/autotruncatelog.cpp
@@ -1,0 +1,40 @@
+//*****************************************************************************
+//*****************************************************************************
+
+
+#include "autotruncatelog.h"
+#include "util.h"
+
+int AutoTruncateLog::init(const std::string& sval, bool isServicenode)
+{
+    int rc{0};
+    try {
+        size_t bigSz{THRESHOLD_MB * ONE_MB};
+        size_t truncate_mb{(not sval.empty()
+                            ? lexical_cast<size_t>(sval)
+                            : (isServicenode
+                               ? DEF_SERVICENODE
+                               : DEF_NON_SERVICENODE))};
+        if (not inRange(truncate_mb)) {
+            rc = 1;
+        } else {
+            size_t newSz{bigSz - truncate_mb * ONE_MB};
+            m_truncSz = TruncateSizes{bigSz,newSz};
+            if (truncate_mb == 0)
+                m_truncSz.disable();
+        }
+    } catch(...) {
+        rc = 2;
+    }
+    return rc;
+}
+
+void AutoTruncateLog::check(size_t height)
+{
+    if (enabled() && checkNow(height)
+        && (height == 0 || m_lastHeightChecked != height))
+    {
+        m_lastHeightChecked = height;
+        TruncateLogKeepRecent(m_truncSz);
+    }
+}

--- a/src/autotruncatelog.h
+++ b/src/autotruncatelog.h
@@ -1,0 +1,105 @@
+//*****************************************************************************
+//*****************************************************************************
+
+#ifndef AUTOTRUNCATELOG_H
+#define AUTOTRUNCATELOG_H
+
+#include <boost/lexical_cast.hpp>
+using boost::lexical_cast;
+
+#include <string>
+
+namespace {
+    constexpr size_t ONE_MB{1024*1024};
+    constexpr size_t BLOCKS_PER_DAY{1440};
+
+    // check debug.log file size only twice a day
+    constexpr size_t BLOCKS_BETWEEN_CHECKS{BLOCKS_PER_DAY/2};
+
+    constexpr size_t MIN_MB{0};
+    constexpr size_t MAX_MB{1024};
+    constexpr size_t THRESHOLD_MB{1024};
+    constexpr size_t DEF_SERVICENODE{0};
+    constexpr size_t DEF_NON_SERVICENODE{512};
+
+    constexpr bool inRange(size_t v) {
+        return (v <= MAX_MB /* && v >= MIN_MB */);
+    }
+
+    constexpr bool checkNow(size_t height) {
+        return (height % BLOCKS_BETWEEN_CHECKS) == 0;
+    }
+
+    static_assert(inRange(THRESHOLD_MB), "");
+    static_assert(inRange(DEF_SERVICENODE), "");
+    static_assert(inRange(DEF_NON_SERVICENODE), "");
+    static_assert(DEF_SERVICENODE <= THRESHOLD_MB, "");
+    static_assert(DEF_NON_SERVICENODE <= THRESHOLD_MB, "");
+} // anonymous
+
+/**
+ * @brief specifies the threshold in bytes that triggers truncation
+ *        and the size of the file after truncation
+ */
+class TruncateSizes {
+ public:
+    TruncateSizes() = default;
+    TruncateSizes(size_t bigSz, size_t newSz)
+     : bigSz(bigSz), newSz(std::min(bigSz,newSz)) {}
+    void disable() { bigSz = 0; }
+    bool enabled() const { return bigSz != 0; }
+    bool tooBig(size_t curSz) const {
+        return enabled() && curSz >= bigSz;
+    }
+    size_t bigSize() const { return bigSz; }
+    size_t newSize() const { return newSz; }
+
+ private:
+    size_t bigSz{0};
+    size_t newSz{0};
+};
+
+/**
+ * @brief Implements the "-autotruncatelog" option
+ */
+class AutoTruncateLog final {
+public:
+    AutoTruncateLog() = default;
+    AutoTruncateLog(size_t bigSz, size_t newSz) : m_truncSz{bigSz, newSz} {}
+
+    /**
+     * @brief Deferred initialization is used when instance is global and configuration
+     *        args are not available for the default constructor.
+     *        Only called if "autotruncatelog" is specified
+     *
+     * @param[in] sval is the value of the "autotruncatelog" config option
+     *            an empty string means use default
+     * @param[in] isServicenode Is used to set defaults when the value of the
+     *            "autotruncatelog" config option is an empty string
+     *
+     * @return 0= success, 1= sval is not in valid range, 2= lexical_cast exception
+     */
+    int init(const std::string& sval, bool isServicenode);
+
+    /**
+     * @brief Called on every accepted new block with the current @p height of the blockchain
+     * @param[in] height (optional) The @p height is used as a low resolution "clock"
+     *            so as to periodically check the "debug.log" file size and truncate
+     *            when it gets too big.  The threshold is currently hard-coded as a
+     *            constexpr THRESHOLD_MB (set to 1 GB).
+     *            A forced check is performed if @p height is omitted, or has a value of zero
+     */
+    void check(size_t height = 0);
+
+    /**
+     * @brief Indicates whether the "-autotruncatelog" option is enabled
+     * @return true, if enabled
+     */
+    bool enabled() const { return m_truncSz.enabled(); }
+
+private:
+    TruncateSizes m_truncSz;
+    size_t m_lastHeightChecked{0};
+};
+
+#endif // AUTOTRUNCATELOG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,7 @@ using namespace std;
  * Global state
  */
 
+AutoTruncateLog global_auto_truncate_log;
 CCriticalSection cs_main;
 
 BlockMap mapBlockIndex;
@@ -3587,6 +3588,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDis
             obfuScationPool.NewBlock();
             servicenodePayments.ProcessBlock(GetHeight() + 10);
             budget.NewBlock();
+            global_auto_truncate_log.check(GetHeight());
         }
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -14,6 +14,7 @@
 #endif
 
 #include "amount.h"
+#include "autotruncatelog.h"
 #include "chain.h"
 #include "chainparams.h"
 #include "coins.h"
@@ -113,6 +114,7 @@ struct BlockHasher {
     size_t operator()(const uint256& hash) const { return hash.GetLow64(); }
 };
 
+extern AutoTruncateLog global_auto_truncate_log;
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
 extern CTxMemPool mempool;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -23,6 +23,8 @@
 #include <stdarg.h>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/iostreams/device/file.hpp>
+#include <boost/iostreams/positioning.hpp>
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/crypto.h> // for OPENSSL_cleanse()
@@ -134,7 +136,7 @@ bool fServer = false;
 string strMiscWarning;
 bool fLogTimestamps = false;
 bool fLogIPs = false;
-volatile bool fReopenDebugLog = false;
+std::atomic<bool> fReopenDebugLog{false}; // set asynchronously by SIGHUP handler
 
 /** Init OpenSSL library multithreading support */
 static CCriticalSection** ppmutexOpenSSL;
@@ -252,6 +254,54 @@ bool LogAcceptCategory(const char* category)
     return true;
 }
 
+/**
+ * @brief Truncate the "debug.log" file if too big, keep most recent lines
+ * @param[in] truncSz struct specifies the threshold in bytes that triggers
+ *            truncation and the size of the file after truncation
+ */
+void TruncateLogKeepRecent(const TruncateSizes& truncSz)
+{
+    namespace bfs = boost::filesystem;
+    namespace bio = boost::iostreams;
+
+    const bfs::path pathLog{GetDataDir()/"debug.log"};
+    const auto fileSz{bfs::file_size(pathLog)};
+    const auto bigSz{truncSz.bigSize()};
+    const auto newSz{truncSz.newSize()};
+
+    LogPrintf("%s: fileSz=%u bigSz=%u newSz=%u\n", __func__, fileSz, bigSz, newSz);
+
+    if (truncSz.tooBig(fileSz)) {
+        const auto path_c_str{pathLog.string().c_str()};
+
+        boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
+
+        const bool wasOpen{fileout != nullptr};
+        if (wasOpen) {
+            fclose(fileout);       // fileout is unbuffered, no need to flush
+            fileout = nullptr;
+        }
+        std::vector<char> buf(newSz);
+        { // use boost for portable support of seek offset greater than 32-bits
+            bio::file_source in{path_c_str};
+            (void) bio::seek(in, -(buf.size()), BOOST_IOS::end);
+            buf.resize(in.read(buf.data(), buf.size()));
+        }
+        fileout = fopen(path_c_str, "w"); // truncates to empty file
+        if (fileout != nullptr) {
+            setbuf(fileout, nullptr); // unbuffered
+            // discard the first line, probably a partial line
+            char* newline = (char*)::memchr( (void*)buf.data(), '\n', buf.size());
+            size_t nskip = newline ? (newline - buf.data() + 1) : 0;
+            (void) fwrite(buf.data()+nskip, 1, buf.size()-nskip, fileout);
+            if (not wasOpen) {
+                fclose(fileout);
+                fileout = nullptr;
+            }
+        }
+    }
+}
+
 int LogPrintStr(const std::string& str)
 {
     int ret = 0; // Returns total number of characters written
@@ -273,7 +323,7 @@ int LogPrintStr(const std::string& str)
             fReopenDebugLog = false;
             boost::filesystem::path pathDebug = GetDataDir() / "debug.log";
             if (freopen(pathDebug.string().c_str(), "a", fileout) != NULL)
-                setbuf(fileout, NULL); // unbuffered
+                setbuf(fileout, nullptr); // unbuffered
         }
 
         // Debug print useful for profiling
@@ -677,23 +727,9 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
 
 void ShrinkDebugFile()
 {
-    // Scroll debug.log if it's getting too big
-    boost::filesystem::path pathLog = GetDataDir() / "debug.log";
-    FILE* file = fopen(pathLog.string().c_str(), "r");
-    if (file && boost::filesystem::file_size(pathLog) > 10 * 1000000) {
-        // Restart the file with some of the end
-        std::vector<char> vch(200000, 0);
-        fseek(file, -((long)vch.size()), SEEK_END);
-        int nBytes = fread(begin_ptr(vch), 1, vch.size(), file);
-        fclose(file);
-
-        file = fopen(pathLog.string().c_str(), "w");
-        if (file) {
-            fwrite(begin_ptr(vch), 1, nBytes, file);
-            fclose(file);
-        }
-    } else if (file != NULL)
-        fclose(file);
+    constexpr size_t bigSz{10 * 1000000}; // ~  10 MB
+    constexpr size_t newSz{200000};       // ~ 200 KB
+    TruncateLogKeepRecent(TruncateSizes{bigSz,newSz});
 }
 
 #ifdef WIN32

--- a/src/util.h
+++ b/src/util.h
@@ -17,10 +17,12 @@
 #include "config/blocknetdx-config.h"
 #endif
 
+#include "autotruncatelog.h"
 #include "compat.h"
 #include "tinyformat.h"
 #include "utiltime.h"
 
+#include <atomic>
 #include <exception>
 #include <map>
 #include <stdint.h>
@@ -56,7 +58,7 @@ extern bool fServer;
 extern std::string strMiscWarning;
 extern bool fLogTimestamps;
 extern bool fLogIPs;
-extern volatile bool fReopenDebugLog;
+extern std::atomic<bool> fReopenDebugLog;
 
 void SetupEnvironment();
 
@@ -125,6 +127,14 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 boost::filesystem::path GetTempPath();
+
+/**
+ * @brief Truncate the "debug.log" file if too big, keep most recent lines
+ * @param[in] truncSz specifies the threshold in bytes that triggers truncation
+ *            and the size of the file after truncation
+ */
+void TruncateLogKeepRecent(const TruncateSizes& truncSz);
+
 void ShrinkDebugFile();
 void runCommand(std::string strCommand);
 


### PR DESCRIPTION
Sets a truncate size in MB when debug.log over 1024 MB, checked twice a day (0-1024, default: 0 for Servicenodes, 512 otherwise)

If “-autotruncatelog” is not specified, or if the value is “0”, the option is disabled.
If “-autotruncatelog” is specified but no value is given the defaults apply.
If “-autotruncatelog=n” is specified and n > 0, then automatic debug.log truncation is in effect, it is checked when the process starts and approximately twice a day thereafter.  When the size of debug.log is found to be greater than 1024 MB (1GB) it will be truncated to a size of (1024 - n) MB.

If “-shrinkdebugfile” is also specified, that check is done first (the current threshold is 10MB and if size exceeds that it is truncated to the most recent 200 KB).

When truncating, characters up to and including the first newline are discarded given that truncating debug.log probably truncated the first line.

Tested on MacOS 10.13.4 with Apple LLVM version 9.1.0 (clang-902.0.39.2)