### PR TITLE
feature-autotruncatelog: new configuration option, -autotruncatelog=<n>

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -82,6 +82,7 @@ BITCOIN_CORE_H = \
   addrman.h \
   alert.h \
   allocators.h \
+  autotruncatelog.h \
   amount.h \
   base58.h \
   bip38.h \
@@ -197,6 +198,7 @@ libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 libbitcoin_server_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS)
 libbitcoin_server_a_SOURCES = \
   addrman.cpp \
+  autotruncatelog.cpp \
   alert.cpp \
   bloom.cpp \
   chain.cpp \

--- a/src/autotruncatelog.cpp
+++ b/src/autotruncatelog.cpp
@@ -1,0 +1,41 @@
+//*****************************************************************************
+//*****************************************************************************
+
+
+#include "autotruncatelog.h"
+#include "util.h"
+
+int AutoTruncateLog::init(const std::string& sval, bool isServicenode)
+{
+    constexpr size_t ONE_MB{1024*1024};
+    int rc{0};
+    try {
+        size_t bigSz{BIG_MB() * ONE_MB};
+        size_t truncate_mb{(not sval.empty()
+                       ? lexical_cast<size_t>(sval)
+                       : (isServicenode
+                          ? SERVICENODE_MB()
+                          : NON_SERVICENODE_MB()))};
+        if (not inRange(truncate_mb)) {
+            rc = 1;
+        } else {
+            size_t newSz{bigSz - truncate_mb * ONE_MB};
+            m_truncSz = TruncateSizes{bigSz,newSz};
+            if (truncate_mb == 0)
+                m_truncSz.disable();
+        }
+    } catch(...) {
+        rc = 2;
+    }
+    return rc;
+}
+
+void AutoTruncateLog::check(size_t height)
+{
+    if (enabled() && checkNow(height)
+        && (height == 0 || m_lastHeightChecked != height))
+    {
+        m_lastHeightChecked = height;
+        TruncateLogKeepRecent(m_truncSz.bigSize(),m_truncSz.newSize());
+    }
+}

--- a/src/autotruncatelog.h
+++ b/src/autotruncatelog.h
@@ -1,0 +1,91 @@
+//*****************************************************************************
+//*****************************************************************************
+
+#ifndef AUTOTRUNCATELOG_H
+#define AUTOTRUNCATELOG_H
+
+#include <boost/lexical_cast.hpp>
+using boost::lexical_cast;
+
+#include <limits>
+#include <string>
+
+/**
+ * @brief Implements the "-autotruncatelog" option
+ */
+class AutoTruncateLog final {
+
+public:
+    static constexpr size_t BIG_MB() { return 1024; }
+    static constexpr size_t MAX_MB() { return BIG_MB(); }
+    static constexpr size_t SERVICENODE_MB() { return 0; }
+    static constexpr size_t NON_SERVICENODE_MB() { return 512; }
+    static constexpr size_t CHECKS_PER_DAY() { return 2; }
+    static constexpr bool inRange(size_t truncate_mb) {
+        return (truncate_mb <= MAX_MB());
+    }
+    static constexpr bool checkNow(size_t height) {
+        return (height % BLOCKS_BETWEEN_CHECKS()) == 0;
+    }
+
+    AutoTruncateLog() = default; // disabled by default
+    AutoTruncateLog(size_t bigSz, size_t newSz) : m_truncSz{bigSz, newSz} {}
+
+    /**
+     * @brief init is called for deferred initialization when an instance is global
+     *        and configuration parameters for the constructor are not available.
+     *
+     * @param[in] sval is the value of the "autotruncatelog" config option,
+     *            an empty string means use default
+     * @param[in] isServicenode is used to set defaults when the value of the
+     *            "autotruncatelog" config option is an empty string
+     *
+     * @return 0= success, 1= sval is not in valid range, 2= lexical_cast exception
+     */
+    int init(const std::string& sval, bool isServicenode);
+
+    /**
+     * @brief Called on every accepted new block with the current @p height of the blockchain
+     * @param[in] height (optional) The @p height is used as a low resolution "clock"
+     *            so as to periodically check the "debug.log" file size and truncate
+     *            when it gets too big.  The threshold is currently hard-coded as a
+     *            constexpr BIG_MB (set to 1 GB).
+     *            A forced check is performed if @p height is omitted, or has a value of zero
+     */
+    void check(size_t height = 0);
+
+    /**
+     * @brief Indicates whether the "-autotruncatelog" option is enabled
+     * @return true, if enabled
+     */
+    bool enabled() const { return m_truncSz.enabled(); }
+
+private:
+    static constexpr size_t BLOCKS_PER_DAY() { return 1440; }
+    static constexpr size_t BLOCKS_BETWEEN_CHECKS() { return BLOCKS_PER_DAY() / CHECKS_PER_DAY(); }
+
+    class TruncateSizes {
+        static constexpr size_t maxBigSz{std::numeric_limits<size_t>::max()};
+    public:
+        TruncateSizes() = default;
+        TruncateSizes(size_t bigSz, size_t newSz)
+            : bigSz(bigSz), newSz(std::min(bigSz,newSz)) {}
+        void disable() { bigSz = maxBigSz; }
+        bool enabled() const { return bigSz != maxBigSz; }
+        size_t bigSize() const { return bigSz; }
+        size_t newSize() const { return newSz; }
+
+    private:
+        size_t bigSz{0};
+        size_t newSz{0};
+    };
+
+    TruncateSizes m_truncSz;
+    size_t m_lastHeightChecked{0};
+};
+
+static_assert(AutoTruncateLog::inRange(AutoTruncateLog::BIG_MB()), "");
+static_assert(AutoTruncateLog::inRange(AutoTruncateLog::SERVICENODE_MB()), "");
+static_assert(AutoTruncateLog::inRange(AutoTruncateLog::NON_SERVICENODE_MB()), "");
+
+#endif // AUTOTRUNCATELOG_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -15,6 +15,7 @@
 #include "activeservicenode.h"
 #include "addrman.h"
 #include "amount.h"
+#include "autotruncatelog.h"
 #include "checkpoints.h"
 #include "compat/sanity.h"
 #include "key.h"
@@ -458,6 +459,14 @@ std::string HelpMessage(HelpMessageMode mode)
             _("In this mode -genproclimit controls how many blocks are generated immediately."));
     }
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
+    {
+        using K = AutoTruncateLog;
+        strUsage += HelpMessageOpt("-autotruncatelog=<n>", strprintf(_("Set truncate size in MB when debug.log over %u MB,"
+                                                                       " checked %u times a day (0-%u, default:"
+                                                                       " %u for Servicenodes, %u otherwise)"),
+                                                                     K::BIG_MB(), K::CHECKS_PER_DAY(), K::MAX_MB(),
+                                                                     K::SERVICENODE_MB(), K::NON_SERVICENODE_MB()));
+    }
     strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
     strUsage += HelpMessageOpt("-litemode=<n>", strprintf(_("Disable all BlocknetDX specific functionality (Servicenodes, Obfuscation, SwiftTX, Budgeting) (0-1, default: %u)"), 0));
 
@@ -941,6 +950,30 @@ bool AppInit2(boost::thread_group& threadGroup)
 #endif
     if (GetBoolArg("-shrinkdebugfile", !fDebug))
         ShrinkDebugFile();
+
+    /**
+     * -autotruncatelog feature is disabled if it is:
+     *    - not specified, or
+     *    - "0", or
+     *    - an empty string (defaults apply) and a Servicenode (which defaults to "0")
+     *
+     * In order to detect the empty string special case, we use the GetArg
+     * function overload with the string 2nd parameter instead of integer
+     */
+    {
+        std::string atl{GetArg("-autotruncatelog","0")};
+        int rc{global_auto_truncate_log.init(atl, GetBoolArg("-servicenode", false))};
+        if (rc != 0) {
+            using K = AutoTruncateLog;
+            return InitError(strprintf(_("Invalid value for -autotruncatelog=<n>: '%s' rc=%d\n"
+                                         "'n' is MB to truncate once debug.log size reaches %u MB\n"
+                                         "valid range is 0 to %u, 0=disable"),
+                                       atl, rc, K::BIG_MB(), K::MAX_MB()));
+        }
+        // Forced check during initialization
+        global_auto_truncate_log.check();
+    }
+
     LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     LogPrintf("BlocknetDX version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,7 @@ using namespace std;
  * Global state
  */
 
+AutoTruncateLog global_auto_truncate_log;
 CCriticalSection cs_main;
 
 BlockMap mapBlockIndex;
@@ -3587,6 +3588,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDis
             obfuScationPool.NewBlock();
             servicenodePayments.ProcessBlock(GetHeight() + 10);
             budget.NewBlock();
+            global_auto_truncate_log.check(GetHeight());
         }
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -14,6 +14,7 @@
 #endif
 
 #include "amount.h"
+#include "autotruncatelog.h"
 #include "chain.h"
 #include "chainparams.h"
 #include "coins.h"
@@ -113,6 +114,7 @@ struct BlockHasher {
     size_t operator()(const uint256& hash) const { return hash.GetLow64(); }
 };
 
+extern AutoTruncateLog global_auto_truncate_log;
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
 extern CTxMemPool mempool;

--- a/src/util.h
+++ b/src/util.h
@@ -21,6 +21,7 @@
 #include "tinyformat.h"
 #include "utiltime.h"
 
+#include <atomic>
 #include <exception>
 #include <map>
 #include <stdint.h>
@@ -56,7 +57,7 @@ extern bool fServer;
 extern std::string strMiscWarning;
 extern bool fLogTimestamps;
 extern bool fLogIPs;
-extern volatile bool fReopenDebugLog;
+extern std::atomic<bool> fReopenDebugLog;
 
 void SetupEnvironment();
 
@@ -125,6 +126,14 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 boost::filesystem::path GetTempPath();
+
+/**
+ * @brief Truncate the "debug.log" file if too big, keep most recent lines
+ * @param[in] bigSz threshold in bytes that triggers truncation
+ * @param[in] newSz size of the file after truncation
+ */
+void TruncateLogKeepRecent(size_t bigSz, size_t newSz);
+
 void ShrinkDebugFile();
 void runCommand(std::string strCommand);
 


### PR DESCRIPTION
Sets a truncate size in MB when debug.log over 1024 MB, checked twice a day (0-1024, default: 0 for Servicenodes, 512 otherwise)

If “-autotruncatelog” is not specified, or if the value is “0”, the option is disabled.
If “-autotruncatelog” is specified but no value is given the defaults apply.
If “-autotruncatelog=n” is specified and n > 0, then automatic debug.log truncation is in effect, it is checked when the process starts and approximately twice a day thereafter.  When the size of debug.log is found to be greater than 1024 MB (1GB) it will be truncated to a size of (1024 - n) MB.

If “-shrinkdebugfile” is also specified, that check is done first (the current threshold is 10MB and if size exceeds that it is truncated to the most recent 200 KB).

When truncating, characters up to and including the first newline are discarded given that truncating debug.log probably truncated the first line.

Tested on MacOS 10.13.4 with Apple LLVM version 9.1.0 (clang-902.0.39.2)