### PR TITLE
Added dxFlushCancelledOrders command/API

### DIFF
--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -6,6 +6,7 @@
 #include "walletmodel.h"
 #include <QLineEdit>
 #include <QMessageBox>
+#include <QStyle>
 #include <boost/lexical_cast.hpp>
 
 using namespace std;

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -113,7 +113,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"dxGetOrderBook", 0},
         {"dxGetOrderBook", 3},
         {"dxGetOrderBook", 4},
-        {"dxGetOrderFills",2}};
+        {"dxFlushCancelledOrders",0},
+        {"dxFlushCancelledOrders",1},
+    };
 
 class CRPCConvertTable
 {

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -377,7 +377,8 @@ static const CRPCCommand vRPCCommands[] =
         {"xbridge", "dxGetOrderBook",                       &dxGetOrderBook,             true, true, true},
         {"xbridge", "dxGetTokenBalances",                   &dxGetTokenBalances,         true, true, true},
         {"xbridge", "dxGetMyOrders",                        &dxGetMyOrders,              true, true, true},
-        {"xbridge", "dxGetLockedUtxos",                     &dxGetLockedUtxos,           true, true, true}
+        {"xbridge", "dxGetLockedUtxos",                     &dxGetLockedUtxos,           true, true, true},
+        {"xbridge", "dxFlushCancelledOrders",               &dxFlushCancelledOrders,     true, true, true},
     #endif // ENABLE_WALLET
 };
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -597,6 +597,31 @@ extern json_spirit::Value dxGetLockedUtxos(const json_spirit::Array& params, boo
  * @return list of currences with balance
  */
 extern json_spirit::Value  dxGetTokenBalances(const json_spirit::Array& params, bool fHelp);
+
+/**
+ * @brief Flush cancelled orders older than given milliseconds
+ * @param params The list of input params:<br>
+ * params[0] : optional parameter, the minimum age of order in milliseconds, the default is to flush all cancelled orders (0 milliseconds) <br>
+ * @param fHelp If is true then an exception with parameter description message will be thrown
+ * @return The list of flushed orders
+ * * Example:<br>
+ * \verbatim
+    dxFlushCancelledOrders 2500
+    {
+        "ageMillis" : 2500,
+        "now" : "20180619T042505.249373",
+        "durationMicrosec" : 7,
+        "flushedOrders" : [
+            {
+                "id" : "1632417312d5ea676abb88b8fb48ace1a11e9b1a937fc24ff79296d9d2963b32",
+                "txtime" : "20180619T042309.149572",
+                "use_count" : 1
+            }
+        ]
+    }
+ * \endverbatim
+ */
+extern json_spirit::Value dxFlushCancelledOrders(const json_spirit::Array& params, bool fHelp);
 /** @} */
 
 

--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -46,6 +46,8 @@ using TransactionPair   = std::pair<uint256, xbridge::TransactionDescrPtr>;
 using RealVector        = std::vector<double>;
 
 using TransactionVector = std::vector<xbridge::TransactionDescrPtr>;
+using ArrayValue = Array::value_type;
+
 namespace bpt           = boost::posix_time;
 
 
@@ -886,6 +888,53 @@ Value dxCancelOrder(const Array &params, bool fHelp)
 
     obj.emplace_back(Pair("status", tx->strState()));
     return obj;
+}
+
+//******************************************************************************
+//******************************************************************************
+Value dxFlushCancelledOrders(const Array &params, bool fHelp)
+{
+    if(fHelp)
+    {
+        throw runtime_error("dxFlushCancelledOrders (ageMillis)\n"
+                            "Flush cancelled orders older than ageMillis");
+    }
+
+    const int ageMillis = params.size() == 0
+        ? 0
+        : (params.size() == 1 ? params[0].get_int() : -1);
+
+    if (ageMillis < 0)
+    {
+        return util::makeError(xbridge::INVALID_PARAMETERS, __FUNCTION__,
+                               "(ageMillis)");
+    }
+
+    const auto minAge = boost::posix_time::millisec{ageMillis};
+
+    LOG() << "rpc flush cancelled orders older than " << minAge << ": " << __FUNCTION__;
+
+    const auto now = boost::posix_time::microsec_clock::universal_time();
+    const auto list = xbridge::App::instance().flushCancelledOrders(minAge);
+    const auto micros = boost::posix_time::time_duration{ boost::posix_time::microsec_clock::universal_time() - now };
+
+    Object result{
+        Pair{"ageMillis",        ageMillis},
+        Pair{"now",              boost::posix_time::to_iso_string(now)},
+        Pair{"durationMicrosec", static_cast<int>(micros.total_microseconds())},
+    };
+    Array a;
+    for(const auto & it : list) {
+        a.emplace_back(
+            ArrayValue{Object{
+                Pair{"id",        it.id.GetHex()},
+                Pair{"txtime",    boost::posix_time::to_iso_string(it.txtime)},
+                Pair{"use_count", it.use_count},
+            }}
+        );
+    }
+    result.emplace_back("flushedOrders", a);
+    return result;
 }
 
 //******************************************************************************

--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -828,7 +828,7 @@ App::flushCancelledOrders(bpt::time_duration minAge) const
                 list.emplace_back(ptr->id,ptr->txtime,ptr.use_count());
                 mp->erase(it++);
             } else {
-                it++;
+                ++it;
             }
         }
     }

--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -39,6 +39,10 @@
 
 #include "posixtimeconversion.h"
 
+using TransactionMap    = std::map<uint256, xbridge::TransactionDescrPtr>;
+using TransactionPair   = std::pair<uint256, xbridge::TransactionDescrPtr>;
+namespace bpt = boost::posix_time;
+
 //*****************************************************************************
 //*****************************************************************************
 XUIConnector xuiConnector;
@@ -803,6 +807,33 @@ std::map<uint256, xbridge::TransactionDescrPtr> App::history() const
 {
     boost::mutex::scoped_lock l(m_p->m_txLocker);
     return m_p->m_historicTransactions;
+}
+
+//******************************************************************************
+//******************************************************************************
+std::vector<App::FlushedOrder>
+App::flushCancelledOrders(bpt::time_duration minAge) const
+{
+    std::vector<App::FlushedOrder> list{};
+    const bpt::ptime keepTime{bpt::microsec_clock::universal_time() - minAge};
+    const std::vector<TransactionMap*> maps{&m_p->m_transactions, &m_p->m_historicTransactions};
+
+    boost::mutex::scoped_lock l{m_p->m_txLocker};
+
+    for(auto mp : maps) {
+        for(auto it = mp->begin(); it != mp->end(); ) {
+            const TransactionDescrPtr & ptr = it->second; 
+            if (ptr->state != xbridge::TransactionDescr::trCancelled
+                && ptr->txtime < keepTime) {
+                list.emplace_back(ptr->id,ptr->txtime,ptr.use_count());
+                mp->erase(it++);
+            } else {
+                it++;
+            }
+        }
+    }
+
+    return list;
 }
 
 //******************************************************************************

--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -823,7 +823,7 @@ App::flushCancelledOrders(bpt::time_duration minAge) const
     for(auto mp : maps) {
         for(auto it = mp->begin(); it != mp->end(); ) {
             const TransactionDescrPtr & ptr = it->second; 
-            if (ptr->state != xbridge::TransactionDescr::trCancelled
+            if (ptr->state == xbridge::TransactionDescr::trCancelled
                 && ptr->txtime < keepTime) {
                 list.emplace_back(ptr->id,ptr->txtime,ptr.use_count());
                 mp->erase(it++);

--- a/src/xbridge/xbridgeapp.h
+++ b/src/xbridge/xbridgeapp.h
@@ -89,6 +89,20 @@ public:
     bool stop();
 
 public:
+    // classes
+    /**
+     * @brief summary info about old orders flushed by flushCancelledOrders()
+     */
+    class FlushedOrder {
+    public:
+        uint256 id;
+        boost::posix_time::ptime txtime;
+        int use_count;
+        FlushedOrder() = delete;
+        FlushedOrder(uint256 id, boost::posix_time::ptime txtime, int use_count)
+            : id{id}, txtime{txtime}, use_count{use_count} {}
+    };
+
     // transactions
 
     /**
@@ -107,6 +121,11 @@ public:
      * @return map of historical transaction (local canceled and finished)
      */
     std::map<uint256, xbridge::TransactionDescrPtr> history() const;
+    /**
+     * @brief flushCancelledOrders with txtime older than minAge
+     * @return list of all flushed orders
+     */
+    std::vector<FlushedOrder> flushCancelledOrders(boost::posix_time::time_duration minAge) const;
 
     /**
      * @brief appendTransaction append transaction into list (map) of transaction if not exits


### PR DESCRIPTION
An optional parameter is minimum age in milliseconds for a cancelled order to be flushed, default is 0 (flush all cancelled orders).

Orders are searched for in m_transactions and m_historicTransactions in xbridge App.
Both are std::map, a call to std::map::erase() is used to remove transactions.  If the reference count of the shared_ptr is one, the destructor should be called for the managed object.

The return value contains an array with the list of flushed orders, including the id, txtime, and the use_count (the reference count of the shared_ptr).

This compiles on MacOS, and has been minimally tested with blocknetdx-cli.