### PR TITLE
Fix eraseExpiredTransactions std::map::erase() invalidates iterator

### DIFF
--- a/src/xbridge/xbridgeexchange.cpp
+++ b/src/xbridge/xbridgeexchange.cpp
@@ -725,17 +725,14 @@ size_t Exchange::eraseExpiredTransactions()
         {
             LOG() << __FUNCTION__ << std::endl << "order expired" << ptr;
 
-            m_p->m_pendingTransactions.erase(it);
+            m_p->m_pendingTransactions.erase(it++);
 
             unlockUtxos(ptr->id());
 
             ++result;
+        } else {
+            ++it;
         }
-
-        if (m_p->m_pendingTransactions.empty())
-            break;
-
-        ++it;
     }
 
     if(result > 0)


### PR DESCRIPTION
The comment in the code is correct. The fix is to post-increment iterator passed as parameter to erase()
and pre-increment in the non-erase path.  The check for container empty() is unnecessary, was removed.