### PR TITLE
Added workaround for gitian build (static linking)

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -389,6 +389,14 @@ qt_blocknetdx_qt_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
 endif
 qt_blocknetdx_qt_LDADD += $(LIBBITCOIN_CLI) $(LIBBITCOIN_COMMON) $(LIBXBRIDGE_XBRIDGE) $(LIBBITCOIN_UTIL) $(LIBBITCOIN_CRYPTO) $(LIBBITCOIN_UNIVALUE) $(LIBLEVELDB) $(LIBMEMENV) \
   $(BOOST_LIBS) $(QT_LIBS) $(QT_DBUS_LIBS) $(QR_LIBS) $(PROTOBUF_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(LIBSECP256K1)
+
+# TODO: This was added as a workaround for gitian builds (static linking)
+#       Without this the link step for qt/blocknetdx-qt resulted in undefined references
+#       The proper fix probably belongs in ./build-aux/m4/bitcoin_qt.m4
+#       and result in the two libraries being repeated within QT_LIBS when linking statically
+#
+qt_blocknetdx_qt_LDADD += -lfontconfig -lfreetype
+
 qt_blocknetdx_qt_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(QT_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 qt_blocknetdx_qt_LIBTOOLFLAGS = --tag CXX
 


### PR DESCRIPTION
Without this the link step for qt/blocknetdx-qt resulted in undefined references
The proper fix probably belongs in ./build-aux/m4/bitcoin_qt.m4
and result in the two libraries being repeated within QT_LIBS when linking statically