### PR TITLE
Coin control fixes

### DIFF
--- a/src/qt/blocknetcoincontrol.cpp
+++ b/src/qt/blocknetcoincontrol.cpp
@@ -61,7 +61,7 @@ BlocknetCoinControlDialog::BlocknetCoinControlDialog(WalletModel *w, QWidget *pa
     feePanel->setContentsMargins(20, 0, 20, 0);
     feePanel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
     feePanelLayout = new QGridLayout;
-    feePanelLayout->setHorizontalSpacing(40);
+    feePanelLayout->setHorizontalSpacing(30);
     feePanel->setLayout(feePanelLayout);
     feePanel->setHidden(true);
 
@@ -109,7 +109,7 @@ BlocknetCoinControlDialog::BlocknetCoinControlDialog(WalletModel *w, QWidget *pa
     contentLayout->addWidget(feePanel);
     contentLayout->addWidget(btnBox);
 
-    this->resize(960, 680);
+    this->resize(1010, 680);
 
     connect(confirmBtn, &QPushButton::clicked, this, [this]() {
         emit accept();

--- a/src/qt/blocknetsendfunds2.cpp
+++ b/src/qt/blocknetsendfunds2.cpp
@@ -342,7 +342,7 @@ BlocknetSendFunds2::BlocknetSendFunds2(WalletModel *w, int id, QFrame *parent) :
     connect(ccSplitOutputCb, SIGNAL(toggled(bool)), this, SLOT(onSplitChanged()));
     connect(ccSplitOutputTi, SIGNAL(editingFinished()), this, SLOT(onSplitChanged()));
     connect(ccInputsBtn, &QPushButton::clicked, this, [this]() {
-        updateCoinControl(); ccDialog->setPayAmount(model->totalRecipientsAmount()); ccDialog->exec();
+        updateCoinControl(); ccDialog->setPayAmount(model->totalRecipientsAmount()); ccDialog->show();
     });
 }
 
@@ -523,6 +523,12 @@ void BlocknetSendFunds2::keyPressEvent(QKeyEvent *event) {
         onNext();
     else if (event->key() == Qt::Key_Escape)
         onBack();
+}
+
+void BlocknetSendFunds2::hideEvent(QHideEvent *qHideEvent) {
+    if (ccDialog->isVisible())
+        ccDialog->reject();
+    QWidget::hideEvent(qHideEvent);
 }
 
 /**

--- a/src/qt/blocknetsendfunds2.h
+++ b/src/qt/blocknetsendfunds2.h
@@ -67,6 +67,7 @@ private slots:
 protected:
     void keyPressEvent(QKeyEvent *event) override;
     void focusInEvent(QFocusEvent *event) override;
+    void hideEvent(QHideEvent *qHideEvent) override;
 
 private:
     int displayUnit;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -566,7 +566,7 @@ WalletModel::FeeResult WalletModel::getFeeInfo(QVector<CoinInput> &inputs, CAmou
     }
 
     return FeeResult{
-        nPayAmount,
+        nAmount,
         nPayFee,
         nAfterFee,
         nChange,


### PR DESCRIPTION
1) Coin control dialog is no longer modal. It will be closed
   automatically if the parent view is hidden.
2) Fixed: Amount not showing up in coin control summary panel.
3) Adjusted the dialog width to fit better