### PR TITLE
Added timeout to 'connect()' in SSLIOStreamDevice, fixes init xbridge…

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -145,6 +145,7 @@ BITCOIN_CORE_H = \
   script/script_error.h \
   serialize.h \
   spork.h \
+  ssliostreamdevice.h \
   streams.h \
   support/cleanse.h \
   sync.h \

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -40,7 +40,6 @@ using namespace std;
 static proxyType proxyInfo[NET_MAX];
 static CService nameProxy;
 static CCriticalSection cs_proxyInfos;
-int nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 bool fNameLookup = false;
 
 static const unsigned char pchIPv4[12] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff};

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -11,16 +11,13 @@
 
 #include "compat.h"
 #include "serialize.h"
+#include "util.h" // for nConnectTimeout
 
 #include <stdint.h>
 #include <string>
 #include <vector>
 
-extern int nConnectTimeout;
 extern bool fNameLookup;
-
-/** -timeout default */
-static const int DEFAULT_CONNECT_TIMEOUT = 5000;
 
 #ifdef WIN32
 // In MSVC, this is defined as a macro, undefine it to prevent a compile and link error

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -6,10 +6,8 @@
 #ifndef BITCOIN_RPCPROTOCOL_H
 #define BITCOIN_RPCPROTOCOL_H
 
-#include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
-#include <boost/iostreams/concepts.hpp>
-#include <boost/iostreams/stream.hpp>
+#include "ssliostreamdevice.h"
+
 #include <list>
 #include <map>
 #include <stdint.h>
@@ -74,74 +72,6 @@ enum RPCErrorCode {
     RPC_WALLET_WRONG_ENC_STATE = -15,      //! Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
     RPC_WALLET_ENCRYPTION_FAILED = -16,    //! Failed to encrypt the wallet
     RPC_WALLET_ALREADY_UNLOCKED = -17,     //! Wallet is already unlocked
-};
-
-/**
- * IOStream device that speaks SSL but can also speak non-SSL
- */
-template <typename Protocol>
-class SSLIOStreamDevice : public boost::iostreams::device<boost::iostreams::bidirectional>
-{
-public:
-    SSLIOStreamDevice(boost::asio::ssl::stream<typename Protocol::socket>& streamIn, bool fUseSSLIn) : stream(streamIn)
-    {
-        fUseSSL = fUseSSLIn;
-        fNeedHandshake = fUseSSLIn;
-    }
-
-    void handshake(boost::asio::ssl::stream_base::handshake_type role)
-    {
-        if (!fNeedHandshake) return;
-        fNeedHandshake = false;
-        stream.handshake(role);
-    }
-    std::streamsize read(char* s, std::streamsize n)
-    {
-        handshake(boost::asio::ssl::stream_base::server); // HTTPS servers read first
-        if (fUseSSL) return stream.read_some(boost::asio::buffer(s, n));
-        return stream.next_layer().read_some(boost::asio::buffer(s, n));
-    }
-    std::streamsize write(const char* s, std::streamsize n)
-    {
-        handshake(boost::asio::ssl::stream_base::client); // HTTPS clients write first
-        if (fUseSSL) return boost::asio::write(stream, boost::asio::buffer(s, n));
-        return boost::asio::write(stream.next_layer(), boost::asio::buffer(s, n));
-    }
-    bool connect(const std::string& server, const std::string& port)
-    {
-        using namespace boost::asio::ip;
-        tcp::resolver resolver(stream.get_io_service());
-        tcp::resolver::iterator endpoint_iterator;
-#if BOOST_VERSION >= 104300
-        try {
-#endif
-            // The default query (flags address_configured) tries IPv6 if
-            // non-localhost IPv6 configured, and IPv4 if non-localhost IPv4
-            // configured.
-            tcp::resolver::query query(server.c_str(), port.c_str());
-            endpoint_iterator = resolver.resolve(query);
-#if BOOST_VERSION >= 104300
-        } catch (boost::system::system_error& e) {
-            // If we at first don't succeed, try blanket lookup (IPv4+IPv6 independent of configured interfaces)
-            tcp::resolver::query query(server.c_str(), port.c_str(), resolver_query_base::flags());
-            endpoint_iterator = resolver.resolve(query);
-        }
-#endif
-        boost::system::error_code error = boost::asio::error::host_not_found;
-        tcp::resolver::iterator end;
-        while (error && endpoint_iterator != end) {
-            stream.lowest_layer().close();
-            stream.lowest_layer().connect(*endpoint_iterator++, error);
-        }
-        if (error)
-            return false;
-        return true;
-    }
-
-private:
-    bool fNeedHandshake;
-    bool fUseSSL;
-    boost::asio::ssl::stream<typename Protocol::socket>& stream;
 };
 
 std::string HTTPPost(const std::string& strMsg, const std::map<std::string, std::string>& mapRequestHeaders);

--- a/src/ssliostreamdevice.h
+++ b/src/ssliostreamdevice.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2018 The Blocknet developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/ssliostreamdevice.h
+++ b/src/ssliostreamdevice.h
@@ -61,7 +61,7 @@ public:
         auto & ios = stream.get_io_service();
         tcp::resolver resolver(ios);
         tcp::resolver::iterator endpoint_iterator;
-	connect_ec = boost::asio::error::host_not_found;
+        connect_ec = boost::asio::error::host_not_found;
         try {
             // The default query (flags address_configured) tries IPv6 if
             // non-localhost IPv6 configured, and IPv4 if non-localhost IPv4
@@ -69,16 +69,16 @@ public:
             tcp::resolver::query query(server.c_str(), port.c_str());
             endpoint_iterator = resolver.resolve(query);
         } catch (boost::system::system_error& e) {
-	    LogPrint("net", "SSLIOStreamDevice: exception resolving %s:%s: %s\n", server, port, e.what());
+            LogPrint("net", "SSLIOStreamDevice: exception resolving %s:%s: %s\n", server, port, e.what());
             // If we at first don't succeed, try blanket lookup (IPv4+IPv6 independent of configured interfaces)
             try {
                 tcp::resolver::query query(server.c_str(), port.c_str(), resolver_query_base::flags());
                 endpoint_iterator = resolver.resolve(query);
-	        connect_ec = boost::asio::error::host_not_found;
+                connect_ec = boost::asio::error::host_not_found;
             } catch (boost::system::system_error& e) {
-	        LogPrint("net", "SSLIOStreamDevice: exception resolving %s:%s: %s\n", server, port, e.what());
- 	        connect_ec = e.code();
-	        return false;
+                LogPrint("net", "SSLIOStreamDevice: exception resolving %s:%s: %s\n", server, port, e.what());
+                connect_ec = e.code();
+                return false;
             }
         }
         try {
@@ -101,8 +101,8 @@ public:
             deadline.async_wait([&](const boost::system::error_code& ec) {
                 // Timer expired or was cancelled
                 LogPrint("net", "SSLIOStreamDevice: async_wait(): deadline=%fsec %s %s:%s\n",
-			 std::chrono::duration<double>(timeout).count(),
-			 ec ? ec.message() : "timer expired", server, port);
+                    std::chrono::duration<double>(timeout).count(),
+                    ec ? ec.message() : "timer expired", server, port);
                 if (!connect_ec) return; // async_connect was successful
                 // Note: race condition here: connection might succeed before socket is closed,
                 //       not worth using a mutex, but must set error code after closing
@@ -111,9 +111,9 @@ public:
               });
             socket.async_connect(*endpoint_iterator++, [&](const boost::system::error_code& ec) {
                 // Connection completed or was cancelled
-                LogPrint("net", "SSLIOStreamDevice: async_connect(): %s %s:%s\n", ec ? ec.message() : "connected to", server, port);
-                deadline.expires_from_now(timeout); // cancel async_wait
                 connect_ec = ec;
+                deadline.expires_from_now(timeout); // cancel async_wait
+                LogPrint("net", "SSLIOStreamDevice: async_connect(): %s %s:%s\n", ec ? ec.message() : "connected to", server, port);
               });
             // concurrently run async_wait and async_connect
             ios.run(); // blocks until both handlers have run

--- a/src/ssliostreamdevice.h
+++ b/src/ssliostreamdevice.h
@@ -1,0 +1,136 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef SSLIOSTREAMDEVICE_H
+#define SSLIOSTREAMDEVICE_H
+
+#include "util.h"
+
+#include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/bind.hpp>
+#include <boost/current_function.hpp>
+#include <boost/iostreams/concepts.hpp>
+#include <boost/iostreams/stream.hpp>
+
+#include <chrono>
+#include <string>
+
+/**
+ * IOStream device that speaks SSL but can also speak non-SSL
+ */
+template <typename Protocol>
+class SSLIOStreamDevice : public boost::iostreams::device<boost::iostreams::bidirectional>
+{
+public:
+    SSLIOStreamDevice(boost::asio::ssl::stream<typename Protocol::socket>& streamIn, bool fUseSSLIn)
+      : stream(streamIn)
+    {
+        fUseSSL = fUseSSLIn;
+        fNeedHandshake = fUseSSLIn;
+    }
+
+    void handshake(boost::asio::ssl::stream_base::handshake_type role)
+    {
+        if (!fNeedHandshake) return;
+        fNeedHandshake = false;
+        stream.handshake(role);
+    }
+    std::streamsize read(char* s, std::streamsize n)
+    {
+        handshake(boost::asio::ssl::stream_base::server); // HTTPS servers read first
+        if (fUseSSL) return stream.read_some(boost::asio::buffer(s, n));
+        return stream.next_layer().read_some(boost::asio::buffer(s, n));
+    }
+    std::streamsize write(const char* s, std::streamsize n)
+    {
+        handshake(boost::asio::ssl::stream_base::client); // HTTPS clients write first
+        if (fUseSSL) return boost::asio::write(stream, boost::asio::buffer(s, n));
+        return boost::asio::write(stream.next_layer(), boost::asio::buffer(s, n));
+    }
+
+    bool connect(const std::string& server, const std::string& port,
+        boost::asio::steady_timer::duration timeout = std::chrono::milliseconds(nConnectTimeout))
+    {
+        using namespace boost::asio::ip;
+        if (timeout <= std::chrono::milliseconds(0))
+            timeout = std::chrono::milliseconds(nConnectTimeout);
+        auto & ios = stream.get_io_service();
+        tcp::resolver resolver(ios);
+        tcp::resolver::iterator endpoint_iterator;
+	connect_ec = boost::asio::error::host_not_found;
+        try {
+            // The default query (flags address_configured) tries IPv6 if
+            // non-localhost IPv6 configured, and IPv4 if non-localhost IPv4
+            // configured.
+            tcp::resolver::query query(server.c_str(), port.c_str());
+            endpoint_iterator = resolver.resolve(query);
+        } catch (boost::system::system_error& e) {
+	    LogPrint("net", "SSLIOStreamDevice: exception resolving %s:%s: %s\n", server, port, e.what());
+            // If we at first don't succeed, try blanket lookup (IPv4+IPv6 independent of configured interfaces)
+            try {
+                tcp::resolver::query query(server.c_str(), port.c_str(), resolver_query_base::flags());
+                endpoint_iterator = resolver.resolve(query);
+	        connect_ec = boost::asio::error::host_not_found;
+            } catch (boost::system::system_error& e) {
+	        LogPrint("net", "SSLIOStreamDevice: exception resolving %s:%s: %s\n", server, port, e.what());
+ 	        connect_ec = e.code();
+	        return false;
+            }
+        }
+        try {
+          tcp::resolver::iterator end;
+          auto & socket = stream.lowest_layer();
+          while (connect_ec && endpoint_iterator != end) {
+            socket.close(); // Ensure it is closed before attempting new connection
+            //
+            // The default timeout for the kernel 'connect()' system call is O/S specific
+            // and can range from 20 to 75 seconds
+            //     http://man7.org/linux/man-pages/man2/connect.2.html
+            //
+            // Use a deadline timer to close the socket and force a cancel of the 'connect()' system call.
+            // Boost's synchronous/blocking 'connect()' is not cancelled by closing the socket,
+            // the connection must be attempted with an asynchronous 'async_connect()' in order to
+            // be able to cancel with a socket close()
+            //
+            boost::asio::steady_timer deadline(ios);
+            deadline.expires_from_now(timeout);
+            deadline.async_wait([&](const boost::system::error_code& ec) {
+                // Timer expired or was cancelled
+                LogPrint("net", "SSLIOStreamDevice: async_wait(): deadline=%fsec %s %s:%s\n",
+			 std::chrono::duration<double>(timeout).count(),
+			 ec ? ec.message() : "timer expired", server, port);
+                if (!connect_ec) return; // async_connect was successful
+                // Note: race condition here: connection might succeed before socket is closed,
+                //       not worth using a mutex, but must set error code after closing
+                socket.close();                             // cancel async_connect
+                connect_ec = boost::asio::error::timed_out; // ... then set the error code
+              });
+            socket.async_connect(*endpoint_iterator++, [&](const boost::system::error_code& ec) {
+                // Connection completed or was cancelled
+                LogPrint("net", "SSLIOStreamDevice: async_connect(): %s %s:%s\n", ec ? ec.message() : "connected to", server, port);
+                deadline.expires_from_now(timeout); // cancel async_wait
+                connect_ec = ec;
+              });
+            // concurrently run async_wait and async_connect
+            ios.run(); // blocks until both handlers have run
+          }
+        } catch (boost::system::system_error& e) {
+            LogPrint("net", "SSLIOStreamDevice: connect exception: %s\n", e.what());
+        }
+        return connect_ec == boost::system::errc::success;
+    }
+
+    boost::system::error_code connect_error_code() const { return connect_ec; }
+    
+ private:
+    bool fNeedHandshake;
+    bool fUseSSL;
+    boost::system::error_code connect_ec;
+    boost::asio::ssl::stream<typename Protocol::socket>& stream;
+};
+
+#endif // SSLIOSTREAMDEVICE_H

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -135,6 +135,7 @@ string strMiscWarning;
 bool fLogTimestamps = false;
 bool fLogIPs = false;
 volatile bool fReopenDebugLog = false;
+int nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 
 /** Init OpenSSL library multithreading support */
 static CCriticalSection** ppmutexOpenSSL;

--- a/src/util.h
+++ b/src/util.h
@@ -58,6 +58,10 @@ extern bool fLogTimestamps;
 extern bool fLogIPs;
 extern volatile bool fReopenDebugLog;
 
+/** -timeout default */
+static const int DEFAULT_CONNECT_TIMEOUT = 5000;
+extern int nConnectTimeout;
+
 void SetupEnvironment();
 
 /** Return true if log accepts specified category */

--- a/src/xbridge/bitcoinrpcconnector.cpp
+++ b/src/xbridge/bitcoinrpcconnector.cpp
@@ -106,7 +106,9 @@ Object CallRPC(const std::string & rpcuser, const std::string & rpcpasswd,
     SSLIOStreamDevice<asio::ip::tcp> d(sslStream, fUseSSL);
     iostreams::stream< SSLIOStreamDevice<asio::ip::tcp> > stream(d);
     if (!d.connect(rpcip, rpcport))
-        throw runtime_error("couldn't connect to server");
+      throw runtime_error("couldn't connect to "
+			  + rpcip +":"+ rpcport
+			  +" : "+ d.connect_error_code().message());
 
     // HTTP basic authentication
     string strUserPass64 = util::base64_encode(rpcuser + ":" + rpcpasswd);


### PR DESCRIPTION
… service

This patch adds a deadline timer to the 'connect()' function of SSLIOStreamDevice.
The xbridge service initialization would sometimes take a long time, showing no progress.  Wallets/coins are enabled in xbridge.conf, where an ip address and port are specified.  If the host at the given ip address was down or unreachable or a firewall was dropping packets with no response then the 'connect()' system call would timeout in the kernel, by an amount specific to each O/S - on MacOS the default is 75 seconds.  If there is an error response from the host then the 'connect()' error is reported immediately.  So xbridge init would eventually complete, but the delay was dependant on how mmany hosts listed in xbridge.conf were unreachable, and how the timeout is configured in the operating system being used.

The fix involves using boost's async_connect() instead of connect(), running it concurrently with an async_wait/deadline timer, canceling the timer if the connect completes first and canceling the connect if the timer expires first.  If the timer expires it closes the socket, which in turn cancels the outstanding connect() system call.  There is a race condition if the timer expires and its handler is invoked right before a successful connection... in this case the timer expiration takes precedence, it will close the connection (which had just successfully completed) and sets te error code to timed_out.

The existing '-timeout' parameter/config option is used to allow adjusting the timeout.  The value is in milliseconds with a default of 5000 (5 seconds).  It is currently used for the same purpose in the networking code for the blockchain protocol in src/netbase.cpp.  Given that netbase.cpp is not included in the client/command line tool (blocknetdx-cli) the default value definition (DEFAULT_CONNECT_TIMEOUT) and the global declaration of nConnectTimeout have been moved from src/netbase to src/util.

The class SSLIOStreamDevice has been moved into its own file, src/ssliostreamdevice.h, previously it was in both a header and a .cpp file (with slightly different implementation).  A new member function has been added, connect_error_code, to retrieve the error from the previous connect() function call, which reeturns a boolean indicating success/failure.  The connect() call now takes an optional 3rd parameter, the duration of the timeout, which defaults to nConnectTimeout if omitted.