### PR TITLE
Enhanced dxGetOrderHistory: add blockchain multisig currency pair trades

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -104,6 +104,7 @@ BITCOIN_CORE_H = \
   primitives/transaction.h \
   core_io.h \
   crypter.h \
+  currencypair.h \
   obfuscation.h \
   obfuscation-relay.h \
   db.h \
@@ -348,6 +349,7 @@ libxbridge_xbridge_a_SOURCES = \
   xbridge/util/settings.cpp \
   xbridge/util/logger.cpp \
   xbridge/util/txlog.cpp \
+  xbridge/util/xseries.cpp \
   xbridge/util/xutil.cpp \
   xbridge/util/xbridgeerror.cpp \
   xbridge/bitcoinrpcconnector.cpp \
@@ -392,6 +394,7 @@ libxbridge_xbridge_a_SOURCES = \
   xbridge/util/settings.h \
   xbridge/util/txlog.h \
   xbridge/util/xassert.h \
+  xbridge/util/xseries.h \
   xbridge/util/xutil.h \
   xbridge/util/xbridgeerror.h \
   xbridge/posixtimeconversion.h \

--- a/src/currencypair.h
+++ b/src/currencypair.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2018 The Blocknet developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef CURRENCYPAIR_H
+#define CURRENCYPAIR_H
+
+#include <boost/date_time/posix_time/ptime.hpp>
+using boost::posix_time::ptime;
+
+#include <cstdint>
+#include <string>
+
+using xid_t = std::string;
+using currencySymbol = std::string;
+
+/**
+ * @brief common structure for currency pair trade details from local history or blockchain
+ */
+class CurrencyPair {
+public:
+    // types
+    using amount_t = uint64_t;
+
+    // variables
+    ptime timeStamp{};
+    std::string xid_or_error;
+    std::string fromCurrency;
+    amount_t fromAmount;
+    std::string toCurrency;
+    amount_t toAmount;
+    enum class Tag { Empty, Error, Valid } tag;
+
+    // ctors
+    CurrencyPair() : tag{Tag::Empty} {}
+    CurrencyPair(const std::string& e) : xid_or_error{e}, tag{Tag::Error} {}
+    CurrencyPair(const xid_t& xid,
+                 std::string fromCurrency, amount_t fromAmount,
+                 std::string toCurrency, amount_t toAmount, ptime ts = ptime{})
+        : timeStamp(ts), xid_or_error(xid)
+        , fromCurrency(fromCurrency), fromAmount(fromAmount)
+        , toCurrency(toCurrency), toAmount(toAmount)
+        , tag{Tag::Valid}
+    {}
+
+    // accessors
+    std::string xid() const { return tag == Tag::Valid ? xid_or_error : std::string{}; }
+    std::string error() const { return tag == Tag::Error ? xid_or_error : std::string{}; }
+};
+
+#endif // CURRENCYPAIR_H

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -112,6 +112,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"dxGetOrderHistory", 5},
         {"dxGetOrderHistory", 6},
         {"dxGetOrderHistory", 7},
+        {"dxGetOrderHistory", 8},
         {"dxGetOrderBook", 0},
         {"dxGetOrderBook", 3},
         {"dxGetOrderBook", 4},

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -110,6 +110,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"dxGetOrderHistory", 3},
         {"dxGetOrderHistory", 4},
         {"dxGetOrderHistory", 5},
+        {"dxGetOrderHistory", 6},
+        {"dxGetOrderHistory", 7},
         {"dxGetOrderBook", 0},
         {"dxGetOrderBook", 3},
         {"dxGetOrderBook", 4},

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -18,6 +18,7 @@
 #include "timedata.h"
 #include "util.h"
 #ifdef ENABLE_WALLET
+#include "currencypair.h"
 #include "wallet.h"
 #include "walletdb.h"
 #endif
@@ -32,6 +33,8 @@ using namespace boost;
 using namespace boost::assign;
 using namespace json_spirit;
 using namespace std;
+
+extern CurrencyPair TxOutToCurrencyPair(const CTxOut & txout, std::string& snode_pubkey);
 
 /**
  * @note Do not add or change anything in the information returned by this
@@ -549,81 +552,37 @@ Value gettradingdata(const Array& params, bool fHelp)
             // throw
             continue;
         }
+        const auto timestamp = block.GetBlockTime();
         for (const CTransaction & tx : block.vtx)
         {
+            const auto txid = tx.GetHash().GetHex();
             for (const CTxOut & out : tx.vout)
             {
-                if (!out.scriptPubKey.size())
-                {
-                    continue;
-                }
-
-                Object o;
-                o.push_back(Pair("timestamp", block.GetBlockTime()));
-
-                std::vector<std::vector<unsigned char> > solutions;
-                txnouttype type = TX_NONSTANDARD;
-                if (!Solver(out.scriptPubKey, type, solutions))
-                {
-                    // wrong pubkey, need to check it
-                    o.push_back(Pair("txid", tx.GetHash().GetHex()));
-                    o.push_back(Pair("xid", "not solved"));
-                    records.push_back(o);
-                    continue;
-                }
-                if (type == TX_MULTISIG)
-                {
-                    if (solutions.size() < 4)
-                    {
-                        o.push_back(Pair("xid", "bad multisig, count of items"));
-                        continue;
-                    }
-
-                    std::string json;
-
-                    o.push_back(Pair("txid", tx.GetHash().GetHex()));
-
-                    {
-                        // second item is real pubkey of service node
-                        CBitcoinAddress snodeAddr(CPubKey(solutions[1]).GetID());
-                        o.push_back(Pair("to", snodeAddr.ToString()));
-                    }
-
-                    for (uint32_t i = 2; i < solutions.size()-1; ++i)
-                    {
-                        const std::vector<unsigned char> & sol = solutions[i];
-                        if (sol.size() != 65)
-                        {
-                            o.push_back(Pair("xid", "unknown multisig, size != 65"));
-                            break;
-                        }
-                        std::copy(sol.begin()+1, sol.end(), std::back_inserter(json));
-                    }
-
-                    Value readed;
-                    if (!read_string(json, readed) || readed.type() != array_type)
-                    {
-                        o.push_back(Pair("xid", "unknown multisig, json error"));
-                    }
-                    else
-                    {
-                        Array xtx = readed.get_array();
-                        if (xtx.size() == 5)
-                        {
-                            o.push_back(Pair("xid",        xtx[0].get_str()));
-                            o.push_back(Pair("from",       xtx[1].get_str()));
-                            o.push_back(Pair("fromAmount", xtx[2].get_int()));
-                            o.push_back(Pair("to",         xtx[3].get_str()));
-                            o.push_back(Pair("toAmount",   xtx[4].get_int()));
-                        }
-                        else
-                        {
-                            o.push_back(Pair("xid", "unknown multisig, bad records count"));
-                        }
-                    }
-
-                    records.push_back(o);
-                    continue;
+                std::string snode_pubkey{};
+                const CurrencyPair p = TxOutToCurrencyPair(out, snode_pubkey);
+                switch(p.tag) {
+                case CurrencyPair::Tag::Error:
+                    records.emplace_back(Object{
+                                Pair{"timestamp",  timestamp},
+                                Pair{"txid",       txid},
+                                Pair{"xid",        p.error()}
+                            });
+                    break;
+                case CurrencyPair::Tag::Valid:
+                    records.emplace_back(Object{
+                                Pair{"timestamp",  timestamp},
+                                Pair{"txid",       txid},
+                                Pair{"to",         snode_pubkey},
+                                Pair{"xid",        p.xid()},
+                                Pair{"from",       p.fromCurrency},
+                                Pair{"fromAmount", p.fromAmount},
+                                Pair{"to",         p.toCurrency},
+                                Pair{"toAmount",   p.toAmount},
+                                });
+                    break;
+                case CurrencyPair::Tag::Empty:
+                default:
+                    break;
                 }
             }
         }

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -19,6 +19,7 @@
 #include "script/standard.h"
 #include "uint256.h"
 #include "coincontrol.h"
+#include "currencypair.h"
 #ifdef ENABLE_WALLET
 #include "wallet.h"
 #endif
@@ -33,6 +34,53 @@ using namespace boost;
 using namespace boost::assign;
 using namespace json_spirit;
 using namespace std;
+
+/**
+ * @brief TxOutToCurrencyPair inspects a CTxOut and returns currency pair transaction info
+ * @param tx - transaction with possible multisig
+ * @param snode_pubkey - (output) the service node public key
+ * @return - currency pair transaction details
+ */
+CurrencyPair TxOutToCurrencyPair(const CTxOut & txout, std::string& snode_pubkey)
+{
+    snode_pubkey.clear();
+
+    if (txout.scriptPubKey.empty())
+        return {};
+
+    std::vector<std::vector<unsigned char> > solutions;
+    txnouttype type = TX_NONSTANDARD;
+    if (not Solver(txout.scriptPubKey, type, solutions))
+        return {"not solved"}; // wrong pubkey, need to check it
+    if (type != TX_MULTISIG)
+        return {}; // only interested in multisig
+    if (solutions.size() < 4)
+        return {"bad multisig, count of items"};
+
+    // Second item is real pubkey of service node
+    snode_pubkey = CBitcoinAddress{CPubKey(solutions[1]).GetID()}.ToString();
+    std::string json;
+    for (size_t i = 2; i < solutions.size()-1; ++i) {
+        const auto& sol = solutions[i];
+        if (sol.size() != 65)
+            return {"unknown multisig, size != 65"};
+        std::copy(sol.begin()+1, sol.end(), std::back_inserter(json));
+    }
+    Value val;
+    if (not read_string(json, val) || val.type() != array_type)
+        return {"unknown multisig, json error"};
+    Array xtx = val.get_array();
+    if (xtx.size() != 5)
+        return {"unknown multisig, bad records count"};
+
+    return CurrencyPair{
+            xtx[0].get_str(),    // xid
+            xtx[1].get_str(),    // fromCurrency
+            xtx[2].get_uint64(), // fromAmount
+            xtx[3].get_str(),    // toCurrency
+            xtx[4].get_uint64()  // toAmount
+            };
+}
 
 void ScriptPubKeyToJSON(const CScript& scriptPubKey, Object& out, bool fIncludeHex)
 {

--- a/src/xbridge/util/xseries.cpp
+++ b/src/xbridge/util/xseries.cpp
@@ -1,0 +1,262 @@
+// Copyright (c) 2018 The Blocknet developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "json/json_spirit_utils.h"
+#include "json/json_spirit_value.h"
+
+#include <assert.h>
+#include "currencypair.h"
+#include "xseries.h"
+#include "xbridge/xbridgetransactiondescr.h"
+#include "xbridge/xbridgeapp.h"
+
+extern CurrencyPair TxOutToCurrencyPair(const CTxOut & txout, std::string& snode_pubkey);
+
+//******************************************************************************
+//******************************************************************************
+namespace {
+    // Helper functions to filter transactions in a query
+    //
+    template<class A, class B> bool is_equivalent_pair(const A& a, const B& b) {
+        return (a.toCurrency == b.toCurrency && a.fromCurrency == b.fromCurrency) ||
+               (a.toCurrency == b.fromCurrency && a.fromCurrency == b.toCurrency);
+    }
+    template<typename T> bool is_too_small(T amount) {
+        return ::fabs(amount) < std::numeric_limits<double>::epsilon();
+    }
+    void transaction_filter(std::vector<CurrencyPair>& matches,
+                            const xbridge::TransactionDescr& tr,
+                            const xQuery& query)
+    {
+        if (not(tr.state == xbridge::TransactionDescr::trFinished)) return;
+        if (not query.period.contains(tr.txtime)) return;
+        if (not is_equivalent_pair(tr, query)) return;
+        if (is_too_small(tr.fromAmount) || is_too_small(tr.toAmount)) return;
+        matches.emplace_back(query.with_txids == xQuery::WithTxids::Included
+                             ? tr.id.GetHex() : xid_t{},
+                             tr.fromCurrency, tr.fromAmount,
+                             tr.toCurrency,   tr.toAmount,
+                             tr.txtime);
+    }
+    void updateXSeries(std::vector<xAggregate>& series,
+                       const xSeriesCache::xRange& r,
+                       const xQuery& q,
+                       xQuery::Transform tf)
+    {
+        for (auto it=r.begin(); it != r.end(); ++it) {
+            auto offset = it->timeEnd - q.period.begin();
+            size_t idx = (offset.total_seconds() - 1) / q.granularity.total_seconds();
+            series.at(idx).update(tf == xQuery::Transform::Invert ? it->inverse() : *it, q.with_txids);
+        }
+    }
+
+
+    std::vector<CurrencyPair> get_tradingdata(time_period query)
+    {
+        LOCK(cs_main);
+
+        std::vector<CurrencyPair> records;
+
+        CBlockIndex * pindex = chainActive.Tip();
+        auto ts = from_time_t(pindex->GetBlockTime());
+        while (pindex->pprev != nullptr && query.end() < ts) {
+            pindex = pindex->pprev;
+            ts = from_time_t(pindex->GetBlockTime());
+        }
+
+        for (; pindex->pprev != nullptr && query.contains(ts);
+             pindex = pindex->pprev, ts = from_time_t(pindex->GetBlockTime()))
+        {
+            CBlock block;
+            if (not ReadBlockFromDisk(block, pindex))
+                continue; // throw?
+            for (const CTransaction & tx : block.vtx)
+            {
+                for (const CTxOut & out : tx.vout)
+                {
+                    std::string snode_pubkey{};
+                    CurrencyPair p = TxOutToCurrencyPair(out, snode_pubkey);
+                    if (p.tag == CurrencyPair::Tag::Valid) {
+                        p.timeStamp = ts;
+                        records.emplace_back(p);
+                    }
+                }
+            }
+        }
+        return records;
+    }
+
+    ptime get_end_time(int64_t end_secs, time_duration period = boost::posix_time::seconds{60}) {
+        const int64_t psec = period.total_seconds();
+        if (end_secs < 0 || psec < 1)
+            return from_time_t(0);
+        return from_time_t(((end_secs + psec - 1) / psec) * psec);
+    }
+}
+
+//******************************************************************************
+//******************************************************************************
+std::vector<xAggregate>
+xSeriesCache::getChainXAggregateSeries(const xQuery& query)
+{
+    xQuery q{query};
+    const size_t query_seconds = q.period.length().total_seconds();
+    const size_t granularity_seconds = q.granularity.total_seconds();
+    const size_t num_intervals = std::min(query_seconds / granularity_seconds,
+                                          q.interval_limit.count);
+    time_duration adjusted_duration = boost::posix_time::seconds{
+        static_cast<long>(num_intervals * granularity_seconds)};
+    q.period = time_period{q.period.end() - adjusted_duration, q.period.end()};
+    std::vector<xAggregate> series{};
+    series.resize(num_intervals,xAggregate{ptime{},0,0,0,0,0,0});
+
+    auto t = q.period.begin();
+    for (size_t i = 0; i < num_intervals; ++i) {
+        t += q.granularity;
+        series[i].timeEnd = t;
+    }
+
+    if (not m_cache_period.contains(q.period))
+        updateSeriesCache(q.period);
+
+    pairSymbol key = q.fromCurrency +"/"+ q.toCurrency;
+    auto range = getXAggregateRange(key, q.period);
+    updateXSeries(series, range, q, xQuery::Transform::None);
+    if (q.with_inverse == xQuery::WithInverse::Included) {
+        key = q.toCurrency +"/"+ q.fromCurrency;
+        range = getXAggregateRange(key, q.period);
+        updateXSeries(series, range, q, xQuery::Transform::Invert);
+    }
+    return series;
+}
+
+//******************************************************************************
+//******************************************************************************
+xSeriesCache::xAggregateContainer&
+xSeriesCache::getXAggregateContainer(const pairSymbol& key)
+{
+    auto f = mSparseSeries.find(key);
+    if (f == mSparseSeries.end()) {
+        mSparseSeries[key] = {};
+        f = mSparseSeries.find(key);
+        assert(f != mSparseSeries.end());
+    }
+    return f->second;
+}
+
+//******************************************************************************
+//******************************************************************************
+xSeriesCache::xRange
+xSeriesCache::getXAggregateRange(const pairSymbol& key, const time_period& period)
+{
+    auto& q = getXAggregateContainer(key);
+    auto low = std::lower_bound(q.begin(), q.end(), period.begin(),
+                                   [](const xAggregate& a, const ptime& b) {
+                                       return a.end_time() <= b; });
+    auto up = std::upper_bound(low, q.end(), period.end(),
+                                [](const ptime& period_end, const xAggregate& b) {
+                                   return period_end <= b.end_time(); });
+    return {low, up};
+}
+
+//******************************************************************************
+//******************************************************************************
+void xSeriesCache::updateSeriesCache(const time_period& period)
+{
+    // TODO(amdn) cached aggregate series for blocks that are purged from the chain
+    // need to be invalidated... this code invalidates on every query to
+    // ensure results are up-to-date, cache can be enabled when invalidation
+    // hook is in place
+    boost::mutex::scoped_lock l(m_xSeriesCacheUpdateLock);
+    std::vector<CurrencyPair> pairs = get_tradingdata(period);
+    std::sort(pairs.begin(), pairs.end(), // ascending by updated time
+              [](const CurrencyPair& a, const CurrencyPair& b) {
+                  return a.timeStamp < b.timeStamp; });
+
+    mSparseSeries.clear();
+    for (const auto& p : pairs) {
+        pairSymbol key = p.fromCurrency +"/"+ p.toCurrency;
+        auto& q = getXAggregateContainer(key);
+        if (q.empty() || q.back().timeEnd <= p.timeStamp) {
+            q.emplace_back(xAggregate{});
+            q.back().timeEnd = get_end_time(to_time_t(p.timeStamp));
+        }
+        q.back().update(p,xQuery::WithTxids::Included);
+    }
+    m_cache_period = period;
+}
+
+//******************************************************************************
+//******************************************************************************
+xAggregate xAggregate::inverse() const {
+    xAggregate x;
+    x.timeEnd = timeEnd;
+    x.orderIds = orderIds;
+    x.open = inverse(open);
+    x.high  = inverse(high);
+    x.low   = inverse(low);
+    x.close = inverse(close);
+    x.toVolume = fromVolume;
+    x.fromVolume = toVolume;
+    return x;
+}
+
+void xAggregate::update(const CurrencyPair& x, xQuery::WithTxids with_txids) {
+    price_t price = x.toAmount == 0
+        ? 0.
+        : static_cast<double>(x.fromAmount) / static_cast<double>(x.toAmount);
+    if (open == 0) {
+        open = high = low = price;
+    }
+    high = std::max(high,price);
+    low  = std::min(low,price);
+    close = price;
+    fromVolume += x.fromAmount;
+    toVolume += x.toAmount;
+    if (with_txids == xQuery::WithTxids::Included)
+        orderIds.push_back(x.xid());
+}
+
+void xAggregate::update(const xAggregate& x, xQuery::WithTxids with_txids) {
+    if (open == 0) {
+        open = high = low = x.open;
+    }
+    high = std::max(high,x.high);
+    low  = std::min(low,x.low);
+    close = x.close;
+    fromVolume += x.fromVolume;
+    toVolume += x.toVolume;
+    if (with_txids == xQuery::WithTxids::Included) {
+        for (const auto& it : x.orderIds)
+            orderIds.push_back(it);
+    }
+}
+
+//******************************************************************************
+//******************************************************************************
+std::vector<xAggregate> xSeriesCache::getXAggregateSeries(const xQuery& query)
+{
+    auto& app = xbridge::App::instance();
+    auto local_matches = app.history_matches(transaction_filter, query);
+
+    std::sort(local_matches.begin(), local_matches.end(), // ascending by updated time
+              [](const CurrencyPair& a, const CurrencyPair& b) {
+                  return a.timeStamp < b.timeStamp; });
+
+    //--Retrieve matching aggregate transactions from blockchain (cached)
+    std::vector<xAggregate> series = getChainXAggregateSeries(query);
+
+    //--Update aggregate from blockchain with transactions from local history
+    auto it = series.begin();
+    auto end = series.end();
+    if (it != end) {
+        for (const auto& x : local_matches) {
+            for ( ; it != end && x.timeStamp < (it->timeEnd - query.granularity); ++it)
+                ;;
+            assert(it != end && x.timeStamp < it->timeEnd);
+            it->update(x,query.with_txids);
+        }
+    }
+    return series;
+}

--- a/src/xbridge/util/xseries.h
+++ b/src/xbridge/util/xseries.h
@@ -1,0 +1,205 @@
+// Copyright (c) 2018 The Blocknet developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XSERIES_H
+#define XSERIES_H
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/ptime.hpp>
+
+#include <cstdint>
+#include <deque>
+#include <unordered_map>
+#include <string>
+#include <vector>
+#include "currencypair.h"
+#include "xutil.h"
+
+#include "json/json_spirit_utils.h"
+#include "json/json_spirit_value.h"
+
+using boost::posix_time::ptime;
+using boost::posix_time::time_period;
+using boost::posix_time::time_duration;
+using boost::posix_time::from_time_t;
+using boost::posix_time::to_time_t;
+using json_spirit::Object;
+using ObjectValue  = Object::value_type;
+using ObjectIL = std::initializer_list<ObjectValue>;
+
+/**
+ * @brief validate and hold parameters used by dxGetOrderHistory() and others
+ */
+class xQuery {
+    const ptime currentTime   = boost::posix_time::microsec_clock::universal_time();
+    const ptime oneDayFromNow = currentTime + boost::gregorian::days{1};
+public:
+// types
+    enum class WithTxids { Excluded, Included };
+    enum class WithInverse { Excluded, Included };
+    enum class Transform { None, Invert };
+    class IntervalLimit {
+    public:
+        size_t count{10};
+        IntervalLimit() = default;
+        IntervalLimit(size_t x) : count(x) {}
+        bool is_valid() const { return min() <= count && count <= max(); }
+        static inline constexpr size_t min() { return 1; }
+        static inline constexpr size_t max() { return 50; }
+    };
+// variables
+    std::string fromCurrency;
+    std::string toCurrency;
+    time_duration granularity;
+    time_period period;
+    WithTxids with_txids;
+    WithInverse with_inverse;
+    IntervalLimit interval_limit;
+    std::string reason;
+
+// constructors
+    xQuery() = delete;
+    xQuery(const std::string& fc,
+           const std::string& tc,
+           int g,
+           int64_t start_time,
+           int64_t end_time,
+           WithTxids with_txids,
+           WithInverse with_inverse,
+           IntervalLimit limit
+        )
+        : fromCurrency{fc}, toCurrency{tc}
+        , granularity{validate_granularity(g)}
+        , period{get_start_time(start_time,granularity), get_end_time(end_time,granularity)}
+        , with_txids{with_txids}
+        , with_inverse{with_inverse}
+        , interval_limit{limit}
+        , reason{(not is_valid_granularity(granularity)) ? ("granularity=" +std::to_string(g)
+                                                        + " must be one of: " + supported_seconds_csv())
+        : (period.begin() < earliestTime()) ? "Start time too early."
+        : (period.is_null()) ? "Start time >= end time."
+        : (period.end() > oneDayFromNow) ? "Start/end times are too large."
+        : (not interval_limit.is_valid()) ? ("Given limit="
+                                             + std::to_string(interval_limit.count)
+                                             + " must be in range "+std::to_string(IntervalLimit::min())
+                                             +" to "+std::to_string(IntervalLimit::max())+".")
+        : ""}
+    {}
+
+// functions
+    bool error() const { return not reason.empty(); }
+    const std::string& what() const { return reason; }
+    static inline ptime earliestTime() {
+        return ptime{boost::gregorian::date{2018, 2, 25}};
+    }
+    static inline std::string supported_seconds_csv() {
+        std::string str{}, s{};
+        for(auto v : supported_seconds()) {
+            str += s + std::to_string(v);
+            s = ",";
+        }
+        return str;
+    }
+
+private:
+    static inline constexpr std::array<int,6> supported_seconds() {
+        return {{ 1*60, 5*60, 15*60, 1*60*60, 6*60*60, 24*60*60 }};
+    }
+    static inline time_duration validate_granularity(int val) {
+        constexpr auto s = supported_seconds();
+        const auto f = std::find(s.begin(), s.end(), val);
+        return boost::posix_time::seconds{f == s.end() ? 0 : *f};
+    }
+    static inline bool is_valid_granularity(const time_duration& td) {
+        constexpr auto s = supported_seconds();
+        return s.end() != std::find(s.begin(), s.end(), td.total_seconds());
+    }
+    static inline ptime get_start_time(int64_t start_secs, time_duration period) {
+        const int64_t psec = period.total_seconds();
+        if (start_secs < 0 || psec < 1)
+            return from_time_t(0);
+        return from_time_t( (start_secs / psec) * psec );
+    }
+    static inline ptime get_end_time(int64_t end_secs, time_duration period) {
+        const int64_t psec = period.total_seconds();
+        if (end_secs < 0 || psec < 1)
+            return from_time_t(0);
+        return from_time_t(((end_secs + psec - 1) / psec) * psec);
+    }
+};
+
+/**
+ * @brief Aggregate transactions for a time interval
+ */
+class xAggregate {
+public:
+
+    // types
+    using price_t = float;
+    using amount_t = uint64_t;
+
+    // variables
+    ptime timeEnd{};
+    price_t open{0};
+    price_t high{0};
+    price_t low{0};
+    price_t close{0};
+    amount_t fromVolume{0};
+    amount_t toVolume{0};
+    std::vector<xid_t> orderIds{};
+
+    // ctors
+    xAggregate() = default;
+    xAggregate(ptime timeEnd,
+               price_t open, price_t high, price_t low, price_t close,
+               amount_t fromVolume, amount_t toVolume)
+    : timeEnd{timeEnd}
+    , open{open}, high{high}, low{low}, close{close}
+    , fromVolume{fromVolume}, toVolume{toVolume}
+    {}
+
+    // helpers
+    static inline price_t inverse(price_t v) {
+        return v < std::numeric_limits<price_t>::epsilon() ? 0. : 1. / v;
+    }
+
+    // accessors
+    xAggregate inverse() const;
+    ptime end_time() const { return timeEnd; }
+
+    // mutators
+    void update(const xAggregate& x, xQuery::WithTxids);
+    void update(const CurrencyPair& x, xQuery::WithTxids);
+};
+
+/**
+ * @brief Cache of open,high,low,close transaction aggregated series
+ */
+class xSeriesCache
+{
+private: // types
+    using pairSymbol = std::string;
+
+public:
+    using xAggregateContainer = std::deque<xAggregate>;
+    using xAggregateIterator = xAggregateContainer::iterator;
+    class xRange {
+    public:
+        xAggregateIterator b;
+        xAggregateIterator e;
+        xAggregateIterator begin() const { return b; }
+        xAggregateIterator end() const { return e; }
+    };
+    xSeriesCache() = default;
+    std::vector<xAggregate> getChainXAggregateSeries(const xQuery&);
+    std::vector<xAggregate> getXAggregateSeries(const xQuery&);
+    xAggregateContainer& getXAggregateContainer(const pairSymbol&);
+    xRange getXAggregateRange(const pairSymbol&, const time_period&);
+    void updateSeriesCache(const time_period&);
+private:
+    boost::mutex m_xSeriesCacheUpdateLock;
+    time_period m_cache_period{ptime{},ptime{}};
+    std::unordered_map<pairSymbol, xAggregateContainer> mSparseSeries;
+};
+#endif // XSERIES_H

--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -8,6 +8,7 @@
 #include "util/settings.h"
 #include "util/xbridgeerror.h"
 #include "util/xassert.h"
+#include "util/xseries.h"
 #include "version.h"
 #include "config.h"
 #include "xuiconnector.h"
@@ -187,6 +188,7 @@ protected:
     boost::mutex                                       m_txLocker;
     std::map<uint256, TransactionDescrPtr>             m_transactions;
     std::map<uint256, TransactionDescrPtr>             m_historicTransactions;
+    xSeriesCache                                       m_xSeriesCache;
 
     // network packets queue
     boost::mutex                                       m_ppLocker;
@@ -823,6 +825,23 @@ std::map<uint256, xbridge::TransactionDescrPtr> App::history() const
     boost::mutex::scoped_lock l(m_p->m_txLocker);
     return m_p->m_historicTransactions;
 }
+
+//******************************************************************************
+//******************************************************************************
+std::vector<CurrencyPair> App::history_matches(const App::TransactionFilter& filter,
+                                          const xQuery& query)
+{
+    std::vector<CurrencyPair> matches{};
+    {
+        boost::mutex::scoped_lock l(m_p->m_txLocker);
+        for(const auto& it : m_p->m_historicTransactions) {
+            filter(matches, *it.second, query);
+        }
+    }
+    return matches;
+}
+
+xSeriesCache& App::getXSeriesCache() { return m_p->m_xSeriesCache; }
 
 //******************************************************************************
 //******************************************************************************

--- a/src/xbridge/xbridgeapp.h
+++ b/src/xbridge/xbridgeapp.h
@@ -16,6 +16,7 @@
 #include <thread>
 #include <atomic>
 #include <vector>
+#include <functional>
 #include <map>
 #include <tuple>
 #include <set>
@@ -24,6 +25,11 @@
 #ifdef WIN32
 // #include <Ws2tcpip.h>
 #endif
+
+class xQuery;
+class CurrencyPair;
+class xAggregate;
+class xSeriesCache;
 
 //*****************************************************************************
 //*****************************************************************************
@@ -104,7 +110,6 @@ public:
     };
 
     // transactions
-
     /**
      * @brief transaction - find transaction by id
      * @param id - id of transaction
@@ -121,6 +126,25 @@ public:
      * @return map of historical transaction (local canceled and finished)
      */
     std::map<uint256, xbridge::TransactionDescrPtr> history() const;
+
+    /**
+     * @brief history_matches returns details of local transactions that match given filter,
+     * it is like the history() call but instead of copying the entire map container it
+     * includes only transactions matching TransactionFilter and xQuery
+     * @param - filter to apply and other query parameters
+     * @return - list of individual matching local transactions
+     */
+    using TransactionFilter = std::function<void(std::vector<CurrencyPair>& matches,
+                                                 const TransactionDescr& tr,
+                                                 const xQuery& query)>;
+    std::vector<CurrencyPair> history_matches(const TransactionFilter& filter, const xQuery& query);
+
+    /**
+     * @brief getXSeriesCache
+     * @return - reference to cache of open,high,low,close transaction aggregated series
+     */
+    xSeriesCache& getXSeriesCache();
+
     /**
      * @brief flushCancelledOrders with txtime older than minAge
      * @return list of all flushed orders


### PR DESCRIPTION

Three new files are added,

src/currencypair.h
src/xbridge/util/xseries.cpp
src/xbridge/util/xseries.h

The CurrencyPair class holds the basic trade details from local history or blockchain that match a query.
CurrencyPair data is aggregated in xAggregate class which is held in containers that summarize trades in a time interval.
Containers of xAggregate include a result vector that is serialized to JSON as a response to an rpc query, and also a cache that keeps aggregated results of currency pair trades recorded as multsig transactions on the blockchain.  The cache is unfinished work, it needs to be invalidated selectively for blocks that are removed from the main blockchain.
Currently the cache is reused provided the time period of queries are contained within the span of previous queries.  The place for this fix is marked with "TODO(amdn)" in the comments.  Various minor bug fixes regarding validation of parameters are included.  Parameters holding Unix (UTC) time in seconds is now parsed as int64 rather than int (year 2038 problem with signed 32-bit integer overflow).  Refactoring was done to create smaller functions.  Time points, time intervals, and time durations are now all kept with boost::posix_time.

dxGetOrderHistory now takes two additional (and optional) parameters.  Taken from the help:

```
 [with_inverse] is a boolean, defaults to false (not aggregating inverse currency pair).
 [limit] is the maximum number of intervals to return, default 10 maximum 50.
```
The limit specified controls the number of (most recent) intervals in the requested period to be returned.
By looking at the timestamp of the oldest interval returned the rpc caller can then submit a subsequent request for contiguous (older) intervals.  This is similar to the parameters used for historical data here, for example:

[cryptocompare.com historical data](https://min-api.cryptocompare.com/data/histominute?fsym=BLOCK&tsym=BTC&limit=60&aggregate=1&toTs=1537403000&extraParams=your_app_name)

Some testing done on MacOS.