### PR TITLE
Improved wallet connection checks

### DIFF
--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -63,8 +63,16 @@ Value dxLoadXBridgeConf(const Array & params, bool fHelp)
         return util::makeError(xbridge::INVALID_PARAMETERS, __FUNCTION__,
                                "This function does not accept any parameter");
 
-    auto success = xbridge::App::instance().loadSettings();
-    xbridge::App::instance().updateActiveWallets();
+    if (ShutdownRequested())
+        throw runtime_error("dxLoadXBridgeConf\nFailed to reload the config because a shutdown request is in progress.");
+
+    auto & app = xbridge::App::instance();
+    if (app.isUpdatingWallets()) // let the user know if wallets are being actively updated
+        throw runtime_error("dxLoadXBridgeConf\nAn existing wallet update is currently in progress, please wait until it has completed.");
+
+    auto success = app.loadSettings();
+    app.clearBadWallets(); // clear any bad wallet designations b/c user is explicitly requesting a wallet update
+    app.updateActiveWallets();
     return success;
 }
 

--- a/src/xbridge/xbridgeapp.h
+++ b/src/xbridge/xbridgeapp.h
@@ -477,6 +477,23 @@ public:
      */
     bool findNodeWithService(const std::set<std::string> & services, CPubKey & node, const std::set<CPubKey> & notIn) const;
 
+    /**
+     * @brief Clears the bad wallet designations.
+     */
+    void clearBadWallets() {
+        LOCK(m_updatingWalletsLock);
+        m_badWallets.clear();
+    }
+
+    /**
+     * @brief Returns true if wallet update checks are already in progress, otherwise returns false.
+     * @return
+     */
+    bool isUpdatingWallets() {
+        LOCK(m_updatingWalletsLock);
+        return m_updatingWallets;
+    }
+
 protected:
     void clearMempool();
 
@@ -484,6 +501,7 @@ private:
     std::unique_ptr<Impl> m_p;
     bool m_disconnecting;
     CCriticalSection m_lock;
+    std::map<std::string, boost::posix_time::ptime> m_badWallets;
     bool m_updatingWallets{false};
     CCriticalSection m_updatingWalletsLock;
 


### PR DESCRIPTION
Wallet checks now happen every 30 seconds (instead of 15s).
An unresponsive wallet will now be designated as a bad wallet
and will incure a 5 minute timeout, at which point the bad
wallet will be checked again.

dxLoadXBridgeConf now indicates whether it succeeded or not.
It will return an error if an existing wallet check or blocknet
shutdown is in progress. dxLoadXBridgeConf also results in
force checking any wallets designated as bad wallets. This is
helpful if a wallet was fixed manually, and the user would like
to force a wallet check in order to bring it online sooner.