### PR TITLE
Improved Servicenode order relay

### DIFF
--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -2399,7 +2399,7 @@ void App::Impl::checkAndRelayPendingOrders() {
         if (!order->isLocal()) // only process local orders
             continue;
 
-        auto pendingOrderShouldRebroadcast = (currentTime - order->txtime).total_seconds() >= 300; // 5min
+        auto pendingOrderShouldRebroadcast = (currentTime - order->txtime).total_seconds() >= 240; // 4min
         auto newOrderShouldRebroadcast = (currentTime - order->txtime).total_seconds() >= 15; // 15sec
 
         if (newOrderShouldRebroadcast && order->state == xbridge::TransactionDescr::trNew)
@@ -2734,17 +2734,6 @@ void App::Impl::onTimer()
 
         // call check expired transactions
         io->post(boost::bind(&xbridge::Session::checkFinishedTransactions, session));
-
-        // send transactions list
-        {
-            static uint32_t counter = 0;
-            if (++counter == 20)
-            {
-                // 15 sec * 20 = 5 min
-                counter = 0;
-                io->post(boost::bind(&xbridge::Session::sendListOfTransactions, session));
-            }
-        }
 
         // update active xwallets (in case a wallet goes offline)
         auto app = &xbridge::App::instance();

--- a/src/xbridge/xbridgeexchange.cpp
+++ b/src/xbridge/xbridgeexchange.cpp
@@ -809,8 +809,12 @@ bool Exchange::updateTimestampOrRemoveExpired(const TransactionPtr & tx)
     // found, check if expired
     if (!m_p->m_pendingTransactions[txid]->isExpired())
     {
+        // return false if update is too soon
+        if (m_p->m_pendingTransactions[txid]->updateTooSoon()) {
+            m_p->m_pendingTransactions[txid]->m_lock.unlock();
+            return false;
+        }
         m_p->m_pendingTransactions[txid]->updateTimestamp();
-
         m_p->m_pendingTransactions[txid]->m_lock.unlock();
         return true;
     }

--- a/src/xbridge/xbridgetransaction.cpp
+++ b/src/xbridge/xbridgetransaction.cpp
@@ -198,6 +198,14 @@ void Transaction::updateTimestamp()
 
 //*****************************************************************************
 //*****************************************************************************
+bool Transaction::updateTooSoon()
+{
+    auto current = boost::posix_time::microsec_clock::universal_time();
+    return (current - m_last).total_seconds() < pendingTTL/2;
+}
+
+//*****************************************************************************
+//*****************************************************************************
 boost::posix_time::ptime Transaction::createdTime() const
 {
     return m_created;
@@ -229,7 +237,7 @@ bool Transaction::isExpired() const
     if (m_state == trNew && tdCreated.total_seconds() > deadlineTTL)
         return true;
 
-    if (m_state == trNew && tdLast.total_seconds() > (pendingTTL*2))
+    if (m_state == trNew && tdLast.total_seconds() > pendingTTL)
         return true;
 
     if (m_state > trNew && tdLast.total_seconds() > TTL)

--- a/src/xbridge/xbridgetransaction.h
+++ b/src/xbridge/xbridgetransaction.h
@@ -112,6 +112,13 @@ public:
      * @brief updateTimestamp - update transaction time
      */
     void updateTimestamp();
+
+    /**
+     * @brief updateTooSoon - Returns true if the order update ping is too soon.
+     * @return true if update is too soon
+     */
+    bool updateTooSoon();
+
     /**
      * @brief createdTime
      * @return time of creation transaction


### PR DESCRIPTION
Servicenodes will now relay orders as they arrive from the network.
They will no longer submit their order book on a timer. It is the
responsibility of the order's Maker to ensure the orders do not
expire.