### PR TITLE
Filter servicenode fee utxos from orders

### DIFF
--- a/src/xbridge/bitcoinrpcconnector.h
+++ b/src/xbridge/bitcoinrpcconnector.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <cstdint>
 
+#include "xbridgewallet.h"
+
 //*****************************************************************************
 //*****************************************************************************
 namespace xbridge
@@ -18,18 +20,29 @@ namespace xbridge
 namespace rpc
 {
     // helper fn-s
+
     /**
-     * @brief storeDataIntoBlockchain
-     * @param dstAddress
+     * @brief Create the Service Node fee payment transaction.
+     * @param dstScript
      * @param amount
      * @param data
+     * @param feeUtxos
+     * @param rawTx
+     * @return
+     */
+    bool createFeeTransaction(const std::vector<unsigned char> & dstScript, const double amount,
+                              const std::vector<unsigned char> & data,
+                              std::set<xbridge::wallet::UtxoEntry> & feeUtxos,
+                              std::string & rawTx);
+
+    /**
+     * @brief storeDataIntoBlockchain Submits the Service Node order fee to the network.
+     * @param rawTx
      * @param txid
      * @return
      */
-    bool storeDataIntoBlockchain(const std::vector<unsigned char> & dstScript,
-                                 const double amount,
-                                 const std::vector<unsigned char> & data,
-                                 std::string & txid);
+    bool storeDataIntoBlockchain(const std::string & rawTx, std::string & txid);
+
 } // namespace rpc
 
 } // namespace xbridge

--- a/src/xbridge/xbridgeapp.h
+++ b/src/xbridge/xbridgeapp.h
@@ -494,6 +494,18 @@ public:
         return m_updatingWallets;
     }
 
+    /**
+     * @brief Lock the specified fee utxos. This prevents fee utxos from being used in orders.
+     * @param feeUtxos
+     */
+    void lockFeeUtxos(std::set<xbridge::wallet::UtxoEntry> & feeUtxos);
+
+    /**
+     * @brief Unlocks the fee utxos, allowing them to be used in orders.
+     * @param feeUtxos
+     */
+    void unlockFeeUtxos(std::set<xbridge::wallet::UtxoEntry> & feeUtxos);
+
 protected:
     void clearMempool();
 
@@ -504,6 +516,9 @@ private:
     std::map<std::string, boost::posix_time::ptime> m_badWallets;
     bool m_updatingWallets{false};
     CCriticalSection m_updatingWalletsLock;
+
+    std::set<xbridge::wallet::UtxoEntry> m_feeUtxos;
+    CCriticalSection m_feeUtxosLock;
 
     /**
      * @brief selectUtxos - Selects available utxos and writes to param outputsForUse.

--- a/src/xbridge/xbridgetransactiondescr.h
+++ b/src/xbridge/xbridgetransactiondescr.h
@@ -115,6 +115,8 @@ struct TransactionDescr
 
     // used coins in transaction
     std::vector<xbridge::wallet::UtxoEntry> usedCoins;
+    std::set<xbridge::wallet::UtxoEntry> feeUtxos;
+    std::string rawFeeTx;
 
     // pay tx verification watches
     uint32_t watchStartBlock{0};


### PR DESCRIPTION
Orders will no longer attempt to use utxos that are designated
for paying service nodes the order fee. The service node fee
payment is now created prior to the order utxo selection algo
and and filtered from the final utxo list.