### PR TITLE
Refund address handling

### DIFF
--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -1420,9 +1420,11 @@ xbridge::Error App::sendXBridgeTransaction(const std::string & from,
     ptr->created      = timestamp;
     ptr->txtime       = timestamp;
     ptr->id           = id;
+    ptr->fromAddr     = from;
     ptr->from         = connFrom->toXAddr(from);
     ptr->fromCurrency = fromCurrency;
     ptr->fromAmount   = fromAmount;
+    ptr->toAddr       = to;
     ptr->to           = connTo->toXAddr(to);
     ptr->toCurrency   = toCurrency;
     ptr->toAmount     = toAmount;
@@ -1762,7 +1764,9 @@ Error App::acceptXBridgeTransaction(const uint256     & id,
         }
     }
 
+    ptr->fromAddr  = from;
     ptr->from      = connFrom->toXAddr(from);
+    ptr->toAddr    = to;
     ptr->to        = connTo->toXAddr(to);
     ptr->role      = 'B';
 

--- a/src/xbridge/xbridgesession.cpp
+++ b/src/xbridge/xbridgesession.cpp
@@ -1783,13 +1783,16 @@ bool Session::Impl::processTransactionCreateA(XBridgePacketPtr packet) const
 
         // outputs
         {
-            std::string addr;
-            if (!connFrom->getNewAddress(addr))
-            {
-                // cancel transaction
-                LOG() << "rpc error, canceling order " << __FUNCTION__;
-                sendCancelTransaction(xtx, crRpcError);
-                return true;
+            std::string addr = xtx->refundAddress();
+            if (addr.empty()) {
+                if (!connFrom->getNewAddress(addr))
+                {
+                    // cancel order
+                    LOG() << "failed to getnewaddress for refund tx, canceling order " << xtx->id.ToString() << " "
+                          << __FUNCTION__;
+                    sendCancelTransaction(xtx, crRpcError);
+                    return true;
+                }
             }
 
             outputs.push_back(std::make_pair(addr, outAmount));
@@ -2210,13 +2213,15 @@ bool Session::Impl::processTransactionCreateB(XBridgePacketPtr packet) const
 
         // outputs
         {
-            std::string addr;
-            if (!connFrom->getNewAddress(addr))
-            {
-                // cancel transaction
-                LOG() << "rpc error, canceling order " << __FUNCTION__;
-                sendCancelTransaction(xtx, crRpcError);
-                return true;
+            std::string addr = xtx->refundAddress();
+            if (addr.empty()) {
+                if (!connFrom->getNewAddress(addr)) {
+                    // cancel order
+                    LOG() << "failed to getnewaddress for refund tx, canceling order " << xtx->id.ToString() << " "
+                          << __FUNCTION__;
+                    sendCancelTransaction(xtx, crRpcError);
+                    return true;
+                }
             }
 
             outputs.push_back(std::make_pair(addr, outAmount));


### PR DESCRIPTION
The refund transaction spending the trader's deposit back
to himself after locktime will prioritize selection of
the refund address in the following manner:
1) Using the from address on the order
2) Using the largest utxo input address for the order
3) Using the wallets getnewaddress rpc call