### PR TITLE
Move on-chain history to OP_RETURN

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -492,8 +492,9 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-swifttxdepth=<n>", strprintf(_("Show N confirmations for a successfully locked transaction (0-9999, default: %u)"), nSwiftTXDepth));
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
-    strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1));
-    strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+// Blocknet requires on-chain data to support order history (no longer user modifiable)
+//    strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1));
+//    strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
     if (GetBoolArg("-help-debug", false)) {
         strUsage += HelpMessageOpt("-blockversion=<n>", "Override block version to test forking scenarios");
     }
@@ -903,7 +904,7 @@ bool AppInit2(boost::thread_group& threadGroup)
 #endif // ENABLE_WALLET
 
     fIsBareMultisigStd = GetArg("-permitbaremultisig", true) != 0;
-    nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);
+//    nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes); // No longer configurable
 
     fAlerts = GetBoolArg("-alerts", DEFAULT_ALERTS);
 

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -120,6 +120,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"dxFlushCancelledOrders",0},
         {"dxFlushCancelledOrders",1},
         {"gettradingdata",0},
+        {"gettradingdata",1},
     };
 
 class CRPCConvertTable

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -195,8 +195,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
             return false;
         if (m < 1 || m > n)
             return false;
-    } else if (whichType == TX_NULL_DATA &&
-                (!GetBoolArg("-datacarrier", true) || scriptPubKey.size() > nMaxDatacarrierBytes))
+    } else if (whichType == TX_NULL_DATA && scriptPubKey.size() > nMaxDatacarrierBytes)
         return false;
 
     return whichType != TX_NONSTANDARD;

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -25,7 +25,8 @@ public:
     CScriptID(const uint160& in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 83;      //!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
+static const unsigned int MAX_OP_RETURN_RELAY_OLD = 83;
+static const unsigned int MAX_OP_RETURN_RELAY = 160;      //!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
 extern unsigned nMaxDatacarrierBytes;
 
 /**

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -92,6 +92,7 @@ bool IsSporkActive(int nSporkID)
         if (nSporkID == SPORK_18_PROPOSAL_FEE) r = SPORK_18_PROPOSAL_FEE_DEFAULT;
         if (nSporkID == SPORK_18_PROPOSAL_FEE_AMOUNT) r = SPORK_18_PROPOSAL_FEE_AMOUNT_DEFAULT;
         if (nSporkID == SPORK_19_SNODE_LIST) r = SPORK_19_SNODE_LIST_DEFAULT;
+        if (nSporkID == SPORK_20_ONCHAIN_HISTORY) r = SPORK_20_ONCHAIN_HISTORY_DEFAULT;
 
         if (r == -1) LogPrintf("GetSpork::Unknown Spork %d\n", nSporkID);
     }
@@ -121,6 +122,7 @@ int64_t GetSporkValue(int nSporkID)
         if (nSporkID == SPORK_18_PROPOSAL_FEE) r = SPORK_18_PROPOSAL_FEE_DEFAULT;
         if (nSporkID == SPORK_18_PROPOSAL_FEE_AMOUNT) r = SPORK_18_PROPOSAL_FEE_AMOUNT_DEFAULT;
         if (nSporkID == SPORK_19_SNODE_LIST) r = SPORK_19_SNODE_LIST_DEFAULT;
+        if (nSporkID == SPORK_20_ONCHAIN_HISTORY) r = SPORK_20_ONCHAIN_HISTORY_DEFAULT;
 
         if (r == -1) LogPrintf("GetSpork::Unknown Spork %d\n", nSporkID);
     }
@@ -269,6 +271,7 @@ int CSporkManager::GetSporkIDByName(std::string strName)
     if (strName == "SPORK_18_PROPOSAL_FEE") return SPORK_18_PROPOSAL_FEE;
     if (strName == "SPORK_18_PROPOSAL_FEE_AMOUNT") return SPORK_18_PROPOSAL_FEE_AMOUNT;
     if (strName == "SPORK_19_SNODE_LIST") return SPORK_19_SNODE_LIST;
+    if (strName == "SPORK_20_ONCHAIN_HISTORY") return SPORK_20_ONCHAIN_HISTORY;
 
     return -1;
 }
@@ -288,6 +291,7 @@ std::string CSporkManager::GetSporkNameByID(int id)
     if (id == SPORK_18_PROPOSAL_FEE) return "SPORK_18_PROPOSAL_FEE";
     if (id == SPORK_18_PROPOSAL_FEE_AMOUNT) return "SPORK_18_PROPOSAL_FEE_AMOUNT";
     if (id == SPORK_19_SNODE_LIST) return "SPORK_19_SNODE_LIST";
+    if (id == SPORK_20_ONCHAIN_HISTORY) return "SPORK_20_ONCHAIN_HISTORY";
 
     return "Unknown";
 }

--- a/src/spork.h
+++ b/src/spork.h
@@ -26,7 +26,7 @@ using namespace boost;
     - This would result in old clients getting confused about which spork is for what
 */
 #define SPORK_START 10001
-#define SPORK_END 10019
+#define SPORK_END 10020
 
 #define SPORK_2_SWIFTTX 10001
 #define SPORK_3_SWIFTTX_BLOCK_FILTERING 10002
@@ -41,6 +41,7 @@ using namespace boost;
 #define SPORK_18_PROPOSAL_FEE 10017
 #define SPORK_18_PROPOSAL_FEE_AMOUNT 10018
 #define SPORK_19_SNODE_LIST 10019
+#define SPORK_20_ONCHAIN_HISTORY 10020
 
 #define SPORK_2_SWIFTTX_DEFAULT 978307200                         //2001-1-1
 #define SPORK_3_SWIFTTX_BLOCK_FILTERING_DEFAULT 1424217600        //2015-2-18
@@ -55,6 +56,7 @@ using namespace boost;
 #define SPORK_18_PROPOSAL_FEE_DEFAULT 4070908800                  //OFF
 #define SPORK_18_PROPOSAL_FEE_AMOUNT_DEFAULT 50                   //50 BLOCK
 #define SPORK_19_SNODE_LIST_DEFAULT 4070908800                    //OFF
+#define SPORK_20_ONCHAIN_HISTORY_DEFAULT 4070908800               //OFF
 
 class CSporkMessage;
 class CSporkManager;

--- a/src/xbridge/bitcoinrpcconnector.cpp
+++ b/src/xbridge/bitcoinrpcconnector.cpp
@@ -184,9 +184,9 @@ bool createFeeTransaction(const std::vector<unsigned char> & dstScript, const do
             std::vector<xbridge::wallet::UtxoEntry> lt;
 
             // Check ideal, find input that is larger than min amount and within range
-            double minAmount{feeAmount(amt, 1, 2)};
+            double minAmount{feeAmount(amt, 1, 3)};
             for (const auto & utxo : a) {
-                if (utxo.amount >= minAmount && utxo.amount < minAmount + estFee(1, 2) * 100) {
+                if (utxo.amount >= minAmount && utxo.amount < minAmount + estFee(1, 3) * 100) {
                     o.push_back(utxo);
                     done = true;
                     break;
@@ -231,7 +231,7 @@ bool createFeeTransaction(const std::vector<unsigned char> & dstScript, const do
                     double runningAmount{0};
                     for (auto & u : sel)
                         runningAmount += u.amount;
-                    runningAmount -= estFee(sel.size(), 2); // subtract estimated fees
+                    runningAmount -= estFee(sel.size(), 3); // subtract estimated fees
 
                     if (runningAmount >= minAmount) {
                         o.insert(o.end(), sel.begin(), sel.end()); // only add utxos if we pass threshold
@@ -257,7 +257,7 @@ bool createFeeTransaction(const std::vector<unsigned char> & dstScript, const do
 
         // Fee amount
         double inputAmt{0};
-        double feeAmt{estFee(selUtxos.size(), 2)};
+        double feeAmt{estFee(selUtxos.size(), 3)};
         std::string changeAddr{selUtxos[0].address};
 
         Array inputs;

--- a/src/xbridge/util/xbridgeerror.cpp
+++ b/src/xbridge/util/xbridgeerror.cpp
@@ -62,6 +62,8 @@ const std::string xbridgeErrorText(const Error & error, const std::string & argu
             return "Blocknet wallet amount is too small to cover the fee payment";
         case NO_SERVICE_NODE:
             return "Could not find a service node with required services: " + argument;
+        case INVALID_ONCHAIN_HISTORY:
+            return "The order information could not be written to the blockchain";
     }
     return "invalid error value";
 }

--- a/src/xbridge/util/xbridgeerror.h
+++ b/src/xbridge/util/xbridgeerror.h
@@ -39,7 +39,8 @@ namespace xbridge
         NOT_EXCHANGE_NODE       = 1029,
         DUST                    = 1030,
         INSIFFICIENT_FUNDS_DX   = 1031,
-        NO_SERVICE_NODE         = 1032
+        NO_SERVICE_NODE         = 1032,
+        INVALID_ONCHAIN_HISTORY = 1033
     };
 
     /**

--- a/src/xbridge/util/xseries.cpp
+++ b/src/xbridge/util/xseries.cpp
@@ -10,7 +10,7 @@
 #include "xbridge/xbridgeapp.h"
 #include "sync.h"
 
-extern CurrencyPair TxOutToCurrencyPair(const CTxOut & txout, std::string& snode_pubkey);
+extern CurrencyPair TxOutToCurrencyPair(const std::vector<CTxOut> & vout, std::string& snode_pubkey);
 
 //******************************************************************************
 //******************************************************************************
@@ -74,14 +74,11 @@ namespace {
                 continue; // throw?
             for (const CTransaction & tx : block.vtx)
             {
-                for (const CTxOut & out : tx.vout)
-                {
-                    std::string snode_pubkey{};
-                    CurrencyPair p = TxOutToCurrencyPair(out, snode_pubkey);
-                    if (p.tag == CurrencyPair::Tag::Valid) {
-                        p.timeStamp = ts;
-                        records.emplace_back(p);
-                    }
+                std::string snode_pubkey{};
+                CurrencyPair p = TxOutToCurrencyPair(tx.vout, snode_pubkey);
+                if (p.tag == CurrencyPair::Tag::Valid) {
+                    p.timeStamp = ts;
+                    records.emplace_back(p);
                 }
             }
         }


### PR DESCRIPTION
Trade fees are now spent directly to the snode p2pkh
instead of a multisig. This allows snodes to properly
spend fees.

OP_RETURN relay size increased to 160 bytes. This allows
more room for storing on-chain order history.

This update is backwards compatible with the existing
multisig implementation.